### PR TITLE
cancelled streamsubscriptions on client close

### DIFF
--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -41,6 +41,7 @@ class CoapClient {
   static final Iterable<CoapWebLink> _emptyLinks = <CoapWebLink>[
     CoapWebLink('')
   ];
+  CoapEndPoint? coapEndPoint;
 
   /// The URI
   Uri uri;
@@ -302,6 +303,7 @@ class CoapClient {
   /// Close the client.
   void close() {
     _log!.info('Close - closing client');
+    coapEndPoint?.stop();
     cancelRequest();
   }
 
@@ -327,7 +329,8 @@ class CoapClient {
     if (endpoint != null) {
       request.endpoint = endpoint;
     } else {
-      request.endpoint = CoapEndPoint(channel, _config);
+      coapEndPoint = CoapEndPoint(channel, _config);
+      request.endpoint = coapEndPoint;
       await request.endpoint!.start();
       endpoint = request.endpoint;
     }

--- a/lib/src/net/coap_endpoint.dart
+++ b/lib/src/net/coap_endpoint.dart
@@ -16,7 +16,7 @@ class CoapEndPoint implements CoapIEndPoint, CoapIOutbox {
     _channel = channel;
     _matcher = CoapMatcher(config);
     _coapStack = CoapStack(config);
-    _eventBus.on<CoapDataReceivedEvent>().listen(_receiveData);
+    subscr = _eventBus.on<CoapDataReceivedEvent>().listen(_receiveData);
   }
 
   /// Instantiates a new endpoint with internet address, port and configuration
@@ -33,6 +33,8 @@ class CoapEndPoint implements CoapIEndPoint, CoapIOutbox {
   DefaultCoapConfig? get config => _config;
   late CoapIChannel _channel;
   late CoapStack _coapStack;
+  StreamSubscription? subscr;
+
   @override
   CoapIMessageDeliverer? deliverer = CoapClientMessageDeliverer();
 
@@ -69,6 +71,8 @@ class CoapEndPoint implements CoapIEndPoint, CoapIOutbox {
     _log!.info(
         'Endpoint - stopping endpoint bound to ${_localEndpoint!.address}');
     _channel.stop();
+    _matcher.stop();
+    subscr?.cancel();
   }
 
   @override

--- a/lib/src/net/coap_matcher.dart
+++ b/lib/src/net/coap_matcher.dart
@@ -15,11 +15,13 @@ class CoapMatcher implements CoapIMatcher {
     if (config.useRandomIDStart) {
       _currentId = Random().nextInt(1 << 16);
     }
-    _eventBus.on<CoapCompletedEvent>().listen(onExchangeCompleted);
+    subscr = _eventBus.on<CoapCompletedEvent>().listen(onExchangeCompleted);
+
   }
 
   final CoapILogger? _log = CoapLogManager().logger;
   final CoapEventBus _eventBus = CoapEventBus();
+  StreamSubscription? subscr;
 
   /// For all
   final Map<CoapKeyId, CoapExchange> _exchangesById =
@@ -44,6 +46,7 @@ class CoapMatcher implements CoapIMatcher {
   @override
   void stop() {
     _deduplicator?.stop();
+    subscr?.cancel();
   }
 
   @override


### PR DESCRIPTION
This change causes the streamsubscriptions to be closed when the function close is called on the CoapClient. This new code allows creating a new client with a new host if the previous client is closed. Note that this means that having multiple clients at the same time is still not possible. 