### PR TITLE
feat: add option to pool udp connections by client instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ defaultBlockSize: 512
 blockwiseStatusLifetime: 60000 # ms
 useRandomIDStart: true
 useRandomTokenStart: true
+poolUdpConnectionsByClient: false
 notificationMaxAge: 128000 # ms
 notificationCheckIntervalTime: 86400000 # ms
 notificationCheckIntervalCount: 100 # ms

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -54,15 +54,13 @@ import 'package:coap/coap.dart';
 /// the config file to contain only those entries that override the defaults.
 /// The file can't be empty, so version must as a minimum be present.
 class $className extends DefaultCoapConfig {
-
   $className() {
     DefaultCoapConfig.inst = this;
   }
- 
+
   @override
   CoapISpec? spec;
-${_generateDataScript(data)}
-}
+${_generateDataScript(data)}}
 """;
 
 String _generateDataScript(YamlMap data) {

--- a/lib/config/coap_config_all.dart
+++ b/lib/config/coap_config_all.dart
@@ -15,52 +15,16 @@ class CoapConfigAll extends DefaultCoapConfig {
   CoapISpec? spec;
 
   @override
-  bool get useRandomIDStart => false;
-
-  @override
-  int get exchangeLifetime => 16;
-
-  @override
-  String get deduplicator => 'MarkAndSweep';
-
-  @override
-  int get defaultBlockSize => 9;
-
-  @override
-  int get cropRotationPeriod => 15;
-
-  @override
-  int get blockwiseStatusLifetime => 10;
-
-  @override
-  int get notificationReregistrationBackoff => 14;
-
-  @override
-  String get logTarget => 'console';
-
-  @override
-  bool get useRandomTokenStart => false;
-
-  @override
-  int get httpPort => 3;
-
-  @override
-  int get notificationCheckIntervalCount => 13;
+  String get version => 'RFC7252';
 
   @override
   int get defaultPort => 1;
 
   @override
-  int get notificationMaxAge => 11;
+  int get defaultSecurePort => 2;
 
   @override
-  bool get logInfo => true;
-
-  @override
-  bool get logError => false;
-
-  @override
-  bool get logDebug => true;
+  int get httpPort => 3;
 
   @override
   int get ackTimeout => 4;
@@ -72,26 +36,65 @@ class CoapConfigAll extends DefaultCoapConfig {
   double get ackTimeoutScale => 6.0;
 
   @override
-  int get defaultSecurePort => 2;
-
-  @override
-  bool get logWarn => true;
-
-  @override
-  String get version => 'RFC7252';
-
-  @override
-  int get channelReceivePacketSize => 18;
-
-  @override
-  int get notificationCheckIntervalTime => 12;
+  int get maxRetransmit => 7;
 
   @override
   int get maxMessageSize => 8;
 
   @override
-  int get maxRetransmit => 7;
+  int get defaultBlockSize => 9;
+
+  @override
+  int get blockwiseStatusLifetime => 10;
+
+  @override
+  bool get useRandomIDStart => false;
+
+  @override
+  bool get useRandomTokenStart => false;
+
+  @override
+  bool get poolUdpConnectionsByClient => false;
+
+  @override
+  int get notificationMaxAge => 11;
+
+  @override
+  int get notificationCheckIntervalTime => 12;
+
+  @override
+  int get notificationCheckIntervalCount => 13;
+
+  @override
+  int get notificationReregistrationBackoff => 14;
+
+  @override
+  int get cropRotationPeriod => 15;
+
+  @override
+  int get exchangeLifetime => 16;
 
   @override
   int get markAndSweepInterval => 17;
+
+  @override
+  int get channelReceivePacketSize => 18;
+
+  @override
+  String get deduplicator => 'MarkAndSweep';
+
+  @override
+  String get logTarget => 'console';
+
+  @override
+  bool get logError => false;
+
+  @override
+  bool get logDebug => true;
+
+  @override
+  bool get logWarn => true;
+
+  @override
+  bool get logInfo => true;
 }

--- a/lib/config/coap_config_all.yaml
+++ b/lib/config/coap_config_all.yaml
@@ -17,6 +17,7 @@ defaultBlockSize: 9
 blockwiseStatusLifetime: 10
 useRandomIDStart: false
 useRandomTokenStart: false
+poolUdpConnectionsByClient: false
 notificationMaxAge: 11
 notificationCheckIntervalTime: 12
 notificationCheckIntervalCount: 13

--- a/lib/config/coap_config_logging.dart
+++ b/lib/config/coap_config_logging.dart
@@ -15,23 +15,23 @@ class CoapConfigLogging extends DefaultCoapConfig {
   CoapISpec? spec;
 
   @override
-  String get logTarget => 'console';
-
-  @override
-  bool get logWarn => true;
-
-  @override
   String get version => 'RFC7252';
 
   @override
   String get deduplicator => 'MarkAndSweep';
 
   @override
-  bool get logInfo => true;
+  String get logTarget => 'console';
 
   @override
   bool get logError => true;
 
   @override
   bool get logDebug => true;
+
+  @override
+  bool get logWarn => true;
+
+  @override
+  bool get logInfo => true;
 }

--- a/lib/src/channel/coap_inetwork.dart
+++ b/lib/src/channel/coap_inetwork.dart
@@ -13,6 +13,9 @@ abstract class CoapINetwork {
   /// The internet address
   CoapInternetAddress? address;
 
+  /// The namespace
+  String namespace = '';
+
   /// The port
   int? port;
 

--- a/lib/src/channel/coap_network_manager.dart
+++ b/lib/src/channel/coap_network_manager.dart
@@ -14,8 +14,10 @@ class CoapNetworkManagement {
 
   /// Gets a new network, otherwise tries to find a cached network
   /// and returns that.
-  static CoapINetwork getNetwork(CoapInternetAddress address, int port) {
-    final CoapINetwork network = CoapNetworkUDP(address, port);
+  static CoapINetwork getNetwork(CoapInternetAddress address, int port,
+      {required String namespace}) {
+    final CoapINetwork network =
+        CoapNetworkUDP(address, port, namespace: namespace);
     if (_networks.contains(network)) {
       return _networks.where((CoapINetwork e) => e == network).toList()[0];
     } else {

--- a/lib/src/channel/coap_network_udp.dart
+++ b/lib/src/channel/coap_network_udp.dart
@@ -10,11 +10,13 @@ part of coap;
 /// UDP network
 class CoapNetworkUDP implements CoapINetwork {
   /// Initialize with an address and a port
-  CoapNetworkUDP(this.address, this.port);
+  CoapNetworkUDP(this.address, this.port, {required this.namespace}) {
+    _eventBus = CoapEventBus(namespace: namespace);
+  }
 
   final CoapILogger? _log = CoapLogManager().logger;
 
-  final CoapEventBus _eventBus = CoapEventBus();
+  late final CoapEventBus _eventBus;
 
   /// The internet address
   @override
@@ -23,6 +25,10 @@ class CoapNetworkUDP implements CoapINetwork {
   /// The port to use for sending.
   @override
   int? port;
+
+  /// The namespace to use
+  @override
+  String namespace = '';
 
   @override
   final StreamController<List<int>> _data =
@@ -121,7 +127,9 @@ class CoapNetworkUDP implements CoapINetwork {
   @override
   bool operator ==(dynamic other) {
     if (other is CoapNetworkUDP) {
-      if (other.port == port && other.address == address) {
+      if (other.port == port &&
+          other.address == address &&
+          other.namespace == namespace) {
         return true;
       }
     }
@@ -134,6 +142,7 @@ class CoapNetworkUDP implements CoapINetwork {
     var result = 17;
     result = 37 * result + port.hashCode;
     result = 37 * result + address.hashCode;
+    result = 37 * result + namespace.hashCode;
     return result;
   }
 }

--- a/lib/src/channel/coap_udp_channel.dart
+++ b/lib/src/channel/coap_udp_channel.dart
@@ -10,8 +10,10 @@ part of coap;
 /// Channel via UDP protocol.
 class CoapUDPChannel extends CoapIChannel {
   /// Initialise with a specific address and port
-  CoapUDPChannel(this._address, this._port) {
-    final socket = CoapNetworkManagement.getNetwork(address!, _port);
+  CoapUDPChannel(this._address, this._port, {required String namespace}) {
+    _eventBus = CoapEventBus(namespace: namespace);
+    final socket =
+        CoapNetworkManagement.getNetwork(address!, _port, namespace: namespace);
     _socket = socket as CoapNetworkUDP;
   }
 
@@ -27,7 +29,7 @@ class CoapUDPChannel extends CoapIChannel {
 
   final typed.Uint8Buffer _buff = typed.Uint8Buffer();
 
-  final CoapEventBus _eventBus = CoapEventBus();
+  late final CoapEventBus _eventBus;
 
   @override
   Future<void> start() async {

--- a/lib/src/coap_config.dart
+++ b/lib/src/coap_config.dart
@@ -58,6 +58,8 @@ abstract class DefaultCoapConfig {
 
   bool get useRandomTokenStart => true;
 
+  bool get poolUdpConnectionsByClient => false;
+
   int get notificationMaxAge => 128 * 1000; // ms
 
   int get notificationCheckIntervalTime => 24 * 60 * 60 * 1000; // ms

--- a/lib/src/coap_message.dart
+++ b/lib/src/coap_message.dart
@@ -47,7 +47,7 @@ class CoapMessage {
   int? id = _initialId.nextInt(initialIdLimit) + 1;
 
   final Map<int, List<CoapOption>> _optionMap = <int, List<CoapOption>>{};
-  final CoapEventBus _eventBus = CoapEventBus();
+  CoapEventBus? _eventBus = CoapEventBus(namespace: '');
 
   /// Option map
   Map<int, List<CoapOption>> get optionMap => _optionMap;
@@ -57,6 +57,12 @@ class CoapMessage {
 
   /// Bind address if not using the default
   InternetAddress? bindAddress;
+
+  void setEventBus(CoapEventBus eventBus) {
+    _eventBus = eventBus;
+  }
+
+  CoapEventBus? get eventBus => _eventBus;
 
   /// Adds an option to the list of options of this CoAP message.
   CoapMessage addOption(CoapOption option) {
@@ -197,7 +203,7 @@ class CoapMessage {
   set isAcknowledged(bool value) {
     _acknowledged = value;
     if (acknowledgedHook == null) {
-      _eventBus.fire(CoapAcknowledgedEvent());
+      _eventBus?.fire(CoapAcknowledgedEvent());
     } else {
       acknowledgedHook!();
     }
@@ -210,7 +216,7 @@ class CoapMessage {
 
   set isRejected(bool value) {
     _rejected = value;
-    _eventBus.fire(CoapRejectedEvent());
+    _eventBus?.fire(CoapRejectedEvent());
   }
 
   bool _timedOut = false;
@@ -224,7 +230,7 @@ class CoapMessage {
   set isTimedOut(bool value) {
     _timedOut = value;
     if (timedOutHook == null) {
-      _eventBus.fire(CoapTimedOutEvent());
+      _eventBus?.fire(CoapTimedOutEvent());
     } else {
       timedOutHook!();
     }
@@ -247,7 +253,7 @@ class CoapMessage {
 
   set isCancelled(bool value) {
     _cancelled = value;
-    _eventBus.fire(CoapCancelledEvent());
+    _eventBus?.fire(CoapCancelledEvent());
   }
 
   /// Indicates whether this message is a duplicate.

--- a/lib/src/coap_observe_client_relation.dart
+++ b/lib/src/coap_observe_client_relation.dart
@@ -14,17 +14,19 @@ part of coap;
 class CoapObserveClientRelation {
   /// Construction
   CoapObserveClientRelation(
-      CoapRequest request, CoapIEndPoint? endpoint, DefaultCoapConfig config) {
+      CoapRequest request, CoapIEndPoint? endpoint, DefaultCoapConfig config,
+      {required String namespace}) {
     _config = config;
     _request = request;
     _endpoint = endpoint;
+    _eventBus = CoapEventBus(namespace: namespace);
     _orderer = CoapObserveNotificationOrderer(config);
     _eventBus.on<CoapReregisteringEvent>().listen(_onReregister);
   }
 
   DefaultCoapConfig? _config;
   CoapRequest? _request;
-  final CoapEventBus _eventBus = CoapEventBus();
+  late final CoapEventBus _eventBus;
 
   /// Request
   CoapRequest? get request => _request;

--- a/lib/src/coap_request.dart
+++ b/lib/src/coap_request.dart
@@ -83,7 +83,7 @@ class CoapRequest extends CoapMessage {
   set response(CoapResponse? value) {
     _currentResponse = value;
     _currentResponse!.timestamp = DateTime.now();
-    _eventBus.fire(CoapRespondEvent(value));
+    _eventBus?.fire(CoapRespondEvent(value));
     // Add to the internal response stream
     _responseStream.add(value);
   }
@@ -171,12 +171,12 @@ class CoapRequest extends CoapMessage {
 
   /// Fire the responding event
   void fireResponding(CoapResponse response) {
-    _eventBus.fire(CoapRespondingEvent(response));
+    _eventBus?.fire(CoapRespondingEvent(response));
   }
 
   /// Fire the reregistering event
   void fireReregistering(CoapRequest request) {
-    _eventBus.fire(CoapReregisteringEvent(request));
+    _eventBus?.fire(CoapReregisteringEvent(request));
   }
 
   /// Stop a request, effectively cancels the request

--- a/lib/src/event/coap_event_bus.dart
+++ b/lib/src/event/coap_event_bus.dart
@@ -133,17 +133,18 @@ class CoapDataReceivedEvent {
 /// Event bus class
 class CoapEventBus {
   /// Construction
-  factory CoapEventBus() => _singleton;
+  factory CoapEventBus({required String namespace}) =>
+      _singletons[namespace] ??= CoapEventBus._internal(namespace);
 
-  CoapEventBus._internal() {
-    _eventBus = events.EventBus();
-  }
+  final String namespace;
+
+  CoapEventBus._internal(this.namespace) : _eventBus = events.EventBus();
 
   /// Last event fired, useful for testing
   dynamic lastEvent;
 
   final CoapILogger? _log = CoapLogManager().logger;
-  late events.EventBus _eventBus;
+  final events.EventBus _eventBus;
   final bool _destroyed = false;
 
   /// Fire
@@ -165,5 +166,5 @@ class CoapEventBus {
     _eventBus.destroy();
   }
 
-  static final CoapEventBus _singleton = CoapEventBus._internal();
+  static final _singletons = <String, CoapEventBus>{};
 }

--- a/lib/src/net/coap_endpoint_manager.dart
+++ b/lib/src/net/coap_endpoint_manager.dart
@@ -16,13 +16,15 @@ class CoapEndpointManager {
   }
 
   /// Default endpoint
-  static CoapIEndPoint getDefaultEndpoint(CoapIEndPoint endpoint) {
+  static CoapIEndPoint getDefaultEndpoint(CoapIEndPoint endpoint,
+      {required String namespace}) {
     final config = DefaultCoapConfig.inst!;
     config.spec ??= CoapDraft18();
     config.defaultPort = config.spec!.defaultPort;
-    final CoapIChannel channel =
-        CoapUDPChannel(endpoint.localEndpoint, config.defaultPort);
-    final ep = CoapEndPoint(channel, config);
+    final CoapIChannel channel = CoapUDPChannel(
+        endpoint.localEndpoint, config.defaultPort,
+        namespace: namespace);
+    final ep = CoapEndPoint(channel, config, namespace: namespace);
     ep.start();
     return ep;
   }

--- a/lib/src/net/coap_exchange.dart
+++ b/lib/src/net/coap_exchange.dart
@@ -15,11 +15,12 @@ part of coap;
 /// i.e., has reached the retransmission limit without being acknowledged.
 class CoapExchange {
   /// Construction
-  CoapExchange(this.request, this._origin) {
+  CoapExchange(this.request, this._origin, {required String namespace}) {
+    _eventBus = CoapEventBus(namespace: namespace);
     _timestamp = DateTime.now();
   }
 
-  final CoapEventBus _eventBus = CoapEventBus();
+  late final CoapEventBus _eventBus;
 
   final Map<Object, Object> _attributes = <Object, Object>{};
   final CoapOrigin _origin;

--- a/lib/src/net/coap_internet_address.dart
+++ b/lib/src/net/coap_internet_address.dart
@@ -39,4 +39,15 @@ class CoapInternetAddress {
       return ipv6DefaultBind;
     }
   }
+
+  /// Equality, deemed to be equal if the address and bind address are the same
+  @override
+  bool operator ==(dynamic other) {
+    if (other is CoapInternetAddress) {
+      if (other.address == address && other.bindAddress == bindAddress) {
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/lib/src/net/coap_matcher.dart
+++ b/lib/src/net/coap_matcher.dart
@@ -10,17 +10,18 @@ part of coap;
 /// Matcher class
 class CoapMatcher implements CoapIMatcher {
   /// Construction
-  CoapMatcher(DefaultCoapConfig config) {
+  CoapMatcher(DefaultCoapConfig config, {required this.namespace}) {
+    _eventBus = CoapEventBus(namespace: namespace);
     _deduplicator = CoapDeduplicatorFactory.createDeduplicator(config);
     if (config.useRandomIDStart) {
       _currentId = Random().nextInt(1 << 16);
     }
     subscr = _eventBus.on<CoapCompletedEvent>().listen(onExchangeCompleted);
-
   }
 
   final CoapILogger? _log = CoapLogManager().logger;
-  final CoapEventBus _eventBus = CoapEventBus();
+  late final CoapEventBus _eventBus;
+  final String namespace;
   StreamSubscription? subscr;
 
   /// For all
@@ -167,7 +168,8 @@ class CoapMatcher implements CoapIMatcher {
 
     if (!request.hasOption(optionTypeBlock1) &&
         !request.hasOption(optionTypeBlock2)) {
-      final exchange = CoapExchange(request, CoapOrigin.remote);
+      final exchange =
+          CoapExchange(request, CoapOrigin.remote, namespace: namespace);
       final previous = _deduplicator!.findPrevious(keyId, exchange);
       if (previous == null) {
         return exchange;
@@ -207,7 +209,8 @@ class CoapMatcher implements CoapIMatcher {
         // hash map 'ongoing' and the deduplicator. They must agree on
         // which exchange they store!
 
-        final exchange = CoapExchange(request, CoapOrigin.remote);
+        final exchange =
+            CoapExchange(request, CoapOrigin.remote, namespace: namespace);
         final previous = _deduplicator!.findPrevious(keyId, exchange);
         if (previous == null) {
           _log!.info(

--- a/lib/src/stack/coap_layer_stack.dart
+++ b/lib/src/stack/coap_layer_stack.dart
@@ -58,7 +58,8 @@ class CoapStackTopLayer extends CoapAbstractLayer {
       CoapINextLayer nextLayer, CoapExchange? exchange, CoapRequest request) {
     var nexchange = exchange;
     if (exchange == null) {
-      nexchange = CoapExchange(request, CoapOrigin.local);
+      nexchange = CoapExchange(request, CoapOrigin.local,
+          namespace: request.eventBus!.namespace);
       nexchange.endpoint = request.endpoint;
     }
     nexchange?.request = request;

--- a/test/coap_message_api_test.dart
+++ b/test/coap_message_api_test.dart
@@ -109,7 +109,7 @@ void main() {
     message.isAcknowledged = true;
     expect(message.isAcknowledged, isTrue);
     expect(acked, isFalse);
-    final eventBus = CoapEventBus();
+    final eventBus = CoapEventBus(namespace: '');
     expect(eventBus.lastEvent is CoapAcknowledgedEvent, isTrue);
     eventBus.lastEvent = null;
     message.acknowledgedHook = ackHook;
@@ -123,7 +123,7 @@ void main() {
     final message = CoapMessage();
     message.isRejected = true;
     expect(message.isRejected, isTrue);
-    final eventBus = CoapEventBus();
+    final eventBus = CoapEventBus(namespace: '');
     expect(eventBus.lastEvent is CoapRejectedEvent, isTrue);
   });
 
@@ -137,7 +137,7 @@ void main() {
     message.isTimedOut = true;
     expect(message.isTimedOut, isTrue);
     expect(timedOut, isFalse);
-    final eventBus = CoapEventBus();
+    final eventBus = CoapEventBus(namespace: '');
     expect(eventBus.lastEvent is CoapTimedOutEvent, isTrue);
     eventBus.lastEvent = null;
     message.timedOutHook = toHook;
@@ -165,7 +165,7 @@ void main() {
     final message = CoapMessage();
     message.isCancelled = true;
     expect(message.isCancelled, isTrue);
-    final eventBus = CoapEventBus();
+    final eventBus = CoapEventBus(namespace: '');
     expect(eventBus.lastEvent is CoapCancelledEvent, isTrue);
     message.isCancelled = false;
     message.cancel();

--- a/test/coap_message_encode_decode_test.dart
+++ b/test/coap_message_encode_decode_test.dart
@@ -884,8 +884,8 @@ void main() {
       response.id = 9;
       response.token = typed.Uint8Buffer()
         ..addAll(<int>[22, 255, 0, 78, 100, 22]);
-      response.addETagOpaque(
-          typed.Uint8Buffer()..addAll(<int>[1, 0, 0, 0, 0, 1]))
+      response
+          .addETagOpaque(typed.Uint8Buffer()..addAll(<int>[1, 0, 0, 0, 0, 1]))
         ..addLocationPath('/one/two/three/four/five/six/seven/eight/nine/ten')
         ..addOption(CoapOption.createVal(
             57453, 0x71ca949f)) // C# 'Arbitrary'.hashCode()

--- a/test/issues/config/coap_config.dart
+++ b/test/issues/config/coap_config.dart
@@ -36,7 +36,7 @@ class CoapConfig extends DefaultCoapConfig {
   double get ackTimeoutScale => 2.0;
 
   @override
-  int get maxRetransmit => 4;
+  int get maxRetransmit => 8;
 
   @override
   int get maxMessageSize => 1024;


### PR DESCRIPTION
Implements #36, Fixes #29

This adds the config option `poolUdpConnectionsByClient` to the config. the default is `false`, meaning current behaviour: if you create more client objects, then they will re-use all those udp connections, provided the remote address is the same. If you set it to `true` then it is namespaced by client object.