### PR TITLE
fix: flutter analyze and flutter format

### DIFF
--- a/lib/src/coap_request.dart
+++ b/lib/src/coap_request.dart
@@ -92,7 +92,7 @@ class CoapRequest extends CoapMessage {
   CoapIEndPoint? endpoint;
 
   /// Resolves the destination internet address
-  Future<CoapInternetAddress> resolveDestination(
+  Future<CoapInternetAddress?> resolveDestination(
           InternetAddressType addressType) async =>
       destination =
           await CoapUtil.lookupHost(resolveHost, addressType, bindAddress);

--- a/lib/src/codec/datagram/coap_datagram_reader.dart
+++ b/lib/src/codec/datagram/coap_datagram_reader.dart
@@ -63,7 +63,8 @@ class CoapDatagramReader {
         bytes.add(read(8));
       }
     } else {
-      final removed = _buffer!.getRange(0, min(bufferCount, _buffer!.length)).toList();
+      final removed =
+          _buffer!.getRange(0, min(bufferCount, _buffer!.length)).toList();
       bytes.insertAll(0, removed);
       _buffer!.removeRange(0, bytes.length);
     }

--- a/lib/src/net/coap_matcher.dart
+++ b/lib/src/net/coap_matcher.dart
@@ -16,7 +16,6 @@ class CoapMatcher implements CoapIMatcher {
       _currentId = Random().nextInt(1 << 16);
     }
     subscr = _eventBus.on<CoapCompletedEvent>().listen(onExchangeCompleted);
-
   }
 
   final CoapILogger? _log = CoapLogManager().logger;

--- a/lib/src/util/coap_util.dart
+++ b/lib/src/util/coap_util.dart
@@ -201,9 +201,9 @@ class CoapUtil {
   }
 
   /// Host lookup, does not use the resolver if the host is an IP address.
-  static Future<CoapInternetAddress> lookupHost(String host,
+  static Future<CoapInternetAddress?> lookupHost(String host,
       InternetAddressType addressType, InternetAddress? bindAddress) async {
-    final completer = Completer<CoapInternetAddress>();
+    final completer = Completer<CoapInternetAddress?>();
     final log = CoapLogManager().logger;
     if (isAnIpAddress(host, addressType)) {
       log!.info(

--- a/test/coap_message_encode_decode_test.dart
+++ b/test/coap_message_encode_decode_test.dart
@@ -884,8 +884,8 @@ void main() {
       response.id = 9;
       response.token = typed.Uint8Buffer()
         ..addAll(<int>[22, 255, 0, 78, 100, 22]);
-      response.addETagOpaque(
-          typed.Uint8Buffer()..addAll(<int>[1, 0, 0, 0, 0, 1]))
+      response
+          .addETagOpaque(typed.Uint8Buffer()..addAll(<int>[1, 0, 0, 0, 0, 1]))
         ..addLocationPath('/one/two/three/four/five/six/seven/eight/nine/ten')
         ..addOption(CoapOption.createVal(
             57453, 0x71ca949f)) // C# 'Arbitrary'.hashCode()


### PR DESCRIPTION
This PR runs `flutter format` and fixes `flutter analyze`.

This is the `flutter analyze` issue that was thrown before:

```
sorunome@sorunome-laptop frontend/coap $ flutter analyze                                                1
Analyzing coap...                                                       

   info • 'Completer.complete' should not be called with a null argument for the non-nullable type
          argument 'CoapInternetAddress' • lib/src/util/coap_util.dart:222:28 •
          null_argument_to_non_null_type

1 issue found. (ran in 4.2s)
```

which kinda negated the nullsafety in this specific aspect