### PR TITLE
fix: use compressed bytes for block option encoding

### DIFF
--- a/lib/src/codec/encoders/coap_message_encoder18.dart
+++ b/lib/src/codec/encoders/coap_message_encoder18.dart
@@ -60,7 +60,11 @@ class CoapMessageEncoder18 extends CoapMessageEncoder {
       }
 
       // Write option value
-      writer.writeBytes(opt.valueBytes);
+      if (opt is CoapBlockOption) {
+        writer.writeBytes(opt.blockValueBytes);
+      } else {
+        writer.writeBytes(opt.valueBytes);
+      }
 
       lastOptionNumber = optNum;
     }


### PR DESCRIPTION
This PR resolves #47 by using the correct getter for block options during encoding. See #47 for more context.