### PR TITLE
fix: remove obsolete CoAP options

### DIFF
--- a/lib/src/coap_message.dart
+++ b/lib/src/coap_message.dart
@@ -66,11 +66,6 @@ class CoapMessage {
 
   /// Adds an option to the list of options of this CoAP message.
   CoapMessage addOption(CoapOption option) {
-    if (option.type == optionTypeToken) {
-      // be compatible with draft 13-
-      token = option.valueBytes;
-      return this;
-    }
     if (!_optionMap.containsKey(option.type)) {
       _optionMap[option.type] = <CoapOption>[];
     }

--- a/lib/src/coap_option.dart
+++ b/lib/src/coap_option.dart
@@ -104,7 +104,6 @@ class CoapOption {
       case optionTypeBlock2:
       case optionTypeBlock1:
       case optionTypeAccept:
-      case optionTypeFencepostDivisor:
         return intValue;
       case optionTypeProxyUri:
       case optionTypeETag:
@@ -112,7 +111,6 @@ class CoapOption {
       case optionTypeLocationPath:
       case optionTypeLocationQuery:
       case optionTypeUriPath:
-      case optionTypeToken:
       case optionTypeUriQuery:
       case optionTypeIfMatch:
       case optionTypeIfNoneMatch:
@@ -128,8 +126,6 @@ class CoapOption {
     switch (_type) {
       case optionTypeMaxAge:
         return intValue == CoapConstants.defaultMaxAge;
-      case optionTypeToken:
-        return valueBytes!.lengthInBytes == 0;
       default:
         return false;
     }
@@ -164,7 +160,6 @@ class CoapOption {
       case optionTypeSize1:
       case optionTypeIfNoneMatch:
       case optionTypeAccept:
-      case optionTypeFencepostDivisor:
         return optionFormat.integer;
       case optionTypeUriHost:
       case optionTypeUriPath:
@@ -173,7 +168,6 @@ class CoapOption {
       case optionTypeLocationQuery:
       case optionTypeProxyUri:
       case optionTypeProxyScheme:
-      case optionTypeToken:
         return optionFormat.string;
       case optionTypeETag:
       case optionTypeIfMatch:
@@ -309,8 +303,6 @@ class CoapOption {
         return 'Location-Query';
       case optionTypeUriPath:
         return 'Uri-Path';
-      case optionTypeToken:
-        return 'Token';
       case optionTypeUriQuery:
         return 'Uri-Query';
       case optionTypeObserve:
@@ -319,8 +311,6 @@ class CoapOption {
         return 'Accept';
       case optionTypeIfMatch:
         return 'If-Match';
-      case optionTypeFencepostDivisor:
-        return 'Fencepost-Divisor';
       case optionTypeBlock2:
         return 'Block2';
       case optionTypeBlock1:

--- a/lib/src/coap_option_type.dart
+++ b/lib/src/coap_option_type.dart
@@ -48,10 +48,6 @@ const int optionTypeUriQuery = 15;
 /// C, Sequence of Bytes, 1-n B, -
 const int optionTypeAccept = 17;
 
-/// C, Sequence of Bytes, 1-2 B, -. NOTE: this option has been replaced with <see cref="Message.Token"/> since draft 13.
-/// draft-ietf-core-coap-03, draft-ietf-core-coap-12</remarks>
-const int optionTypeToken = 19;
-
 /// E, String, 1-270 B, -
 const int optionTypeLocationQuery = 20;
 
@@ -71,9 +67,6 @@ const int optionTypeObserve = 6;
 const int optionTypeBlock2 = 23;
 const int optionTypeBlock1 = 27;
 const int optionTypeSize2 = 28;
-
-/// no-op for fenceposting
-const int optionTypeFencepostDivisor = 114;
 
 /// CoAP option formats
 enum optionFormat { integer, string, opaque, unknown }

--- a/lib/src/codec/encoders/coap_message_encoder_rfc7252.dart
+++ b/lib/src/codec/encoders/coap_message_encoder_rfc7252.dart
@@ -28,9 +28,7 @@ class CoapMessageEncoderRfc7252 extends CoapMessageEncoder {
         options, (dynamic a, dynamic b) => a.type.compareTo(b.type));
 
     for (final opt in options) {
-      if (opt.type == optionTypeToken ||
-          opt.type == optionTypeUriHost ||
-          opt.type == optionTypeUriPort) {
+      if (opt.type == optionTypeUriHost || opt.type == optionTypeUriPort) {
         continue;
       }
 

--- a/test/coap_option_test.dart
+++ b/test/coap_option_test.dart
@@ -88,8 +88,6 @@ void main() {
       final opt =
           CoapOption.createVal(optionTypeMaxAge, CoapConstants.defaultMaxAge);
       expect(opt.isDefault(), isTrue);
-      final opt1 = CoapOption.create(optionTypeToken);
-      expect(opt1.isDefault(), isTrue);
       final opt2 = CoapOption.create(optionTypeReserved);
       expect(opt2.isDefault(), isFalse);
     });
@@ -124,46 +122,6 @@ void main() {
 
       expect(opt1 == opt2, isFalse);
       expect(opt2 == opt22, isTrue);
-    });
-
-    test('Empty token', () {
-      final opt1 = CoapOption.create(optionTypeToken);
-      final opt2 = CoapOption.create(optionTypeToken);
-      final opt22 = CoapOption.createString(optionTypeToken, 'full');
-
-      expect(opt1 == opt2, isTrue);
-      expect(opt2 == opt22, isFalse);
-      expect(opt1.length, 0);
-    });
-
-    test('1 Byte token', () {
-      final opt1 = CoapOption.createVal(optionTypeToken, 0xCD);
-      final opt2 = CoapOption.createVal(optionTypeToken, 0xCD);
-      final opt22 = CoapOption.createVal(optionTypeToken, 0xCE);
-
-      expect(opt1 == opt2, isTrue);
-      expect(opt2 == opt22, isFalse);
-      expect(opt1.length, 1);
-    });
-
-    test('2 Byte token', () {
-      final opt1 = CoapOption.createVal(optionTypeToken, 0xABCD);
-      final opt2 = CoapOption.createVal(optionTypeToken, 0xABCD);
-      final opt22 = CoapOption.createVal(optionTypeToken, 0xABCE);
-
-      expect(opt1 == opt2, isTrue);
-      expect(opt2 == opt22, isFalse);
-      expect(opt1.length, 2);
-    });
-
-    test('4 Byte token', () {
-      final opt1 = CoapOption.createVal(optionTypeToken, 0x1234ABCD);
-      final opt2 = CoapOption.createVal(optionTypeToken, 0x1234ABCD);
-      final opt22 = CoapOption.createVal(optionTypeToken, 0x1234ABCE);
-
-      expect(opt1 == opt2, isTrue);
-      expect(opt2 == opt22, isFalse);
-      expect(opt1.length, 4);
     });
 
     test('Set value', () {


### PR DESCRIPTION
This PR cleans up the project by removing a number of option definitions that have become obsolete in later drafts and RFC 7252.