### PR TITLE
docs: replace draft references with RFC numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/shamblett/coap.svg?branch=master)](https://travis-ci.org/shamblett/coap)
 # coap
 A CoAP client library for Dart developers.
-The Constrained Application Protocol ([CoAP](https://datatracker.ietf.org/doc/draft-ietf-core-coap/))
+The Constrained Application Protocol ([CoAP](https://datatracker.ietf.org/doc/html/rfc7252))
 is a RESTful web transfer protocol for resource-constrained networks and nodes.
 COAP is an implementation in Dart providing CoAP-based services to Dart applications.
 The code is a port from the C# .NET project [CoAP.NET](https://github.com/smeshlink/CoAP.NET). The dart implementation is that

--- a/lib/src/coap_code.dart
+++ b/lib/src/coap_code.dart
@@ -7,8 +7,8 @@
 
 part of coap;
 
-/// This class describes the CoAP Code Registry as defined in
-/// draft-ietf-core-coap-08, section 11.1
+/// This class describes the CoAP Code Registry as defined in  RFC 7252,
+/// section 12.1.
 class CoapCode {
   /// Not set
   static const int notSet = -1;
@@ -80,7 +80,7 @@ class CoapCode {
   /// 4.06 Not Acceptable
   static const int notAcceptable = 134;
 
-  /// 4.08 Request Entity Incomplete (draft-ietf-core-block)
+  /// 4.08 Request Entity Incomplete (RFC 7959)
   static const int requestEntityIncomplete = 136;
 
   /// 4.12 Client not supported by server/headers don't satisfy protocol
@@ -267,7 +267,7 @@ class CoapCode {
   /// 4.06 Not Acceptable
   static const int statusCodeNotAcceptable = 134;
 
-  /// 4.08 Request Entity Incomplete (draft-ietf-core-block)
+  /// 4.08 Request Entity Incomplete (RFC 7959)
   static const int statusCodeRequestEntityIncomplete = 136;
 
   /// 4.12 Precondition failed

--- a/lib/src/coap_link_format.dart
+++ b/lib/src/coap_link_format.dart
@@ -7,8 +7,7 @@
 
 part of coap;
 
-/// This class provides link format definitions as specified in
-/// draft-ietf-core-link-format-06
+/// This class provides link format definitions as specified in RFC 6690.
 class CoapLinkFormat {
   /// Name of the attribute Resource Type
   static const String resourceType = 'rt';

--- a/lib/src/coap_option.dart
+++ b/lib/src/coap_option.dart
@@ -122,8 +122,7 @@ class CoapOption {
     }
   }
 
-  /// Gets a value indicating whether the option has a default value
-  /// according to the draft.
+  /// Checks whether the option value is the default.
   bool isDefault() {
     switch (_type) {
       case optionTypeMaxAge:

--- a/lib/src/observe/coap_observe_notification_orderer.dart
+++ b/lib/src/observe/coap_observe_notification_orderer.dart
@@ -48,7 +48,7 @@ class CoapObserveNotificationOrderer {
     // Multiple responses with different notification numbers might
     // arrive and be processed by different threads. We have to
     // ensure that only the most fresh one is being delivered.
-    // We use the notation from the observe draft-08.
+    // We use the notation from RFC 7641.
     final t1 = timestamp;
     final t2 = DateTime.now();
     final v1 = current!;

--- a/lib/src/specification/rfcs/coap_rfc7252.dart
+++ b/lib/src/specification/rfcs/coap_rfc7252.dart
@@ -60,7 +60,7 @@ class CoapRfc7252 implements CoapISpec {
       newMessageDecoder(bytes).decodeMessage();
 
   /// Calculates the value used in the extended option fields as specified
-  /// in draft-ietf-core-coap-18, section 3.1.
+  /// in RFC 7252, section 3.1.
   static int getValueFromOptionNibble(
       int nibble, CoapDatagramReader? datagram) {
     if (nibble < 13) {


### PR DESCRIPTION
This PR updates the documentation and replaces draft references with RFC numbers where needed.