### PR TITLE
fix: apply fixes to basic multicast scenario

### DIFF
--- a/lib/coap.dart
+++ b/lib/coap.dart
@@ -136,6 +136,8 @@ part 'src/stack/coap_chain.dart';
 
 part 'src/stack/coap_layer_stack.dart';
 
+part 'src/net/coap_multicast_exchange.dart';
+
 part 'src/stack/coap_observe_layer.dart';
 
 part 'src/stack/coap_reliability_layer.dart';

--- a/lib/src/channel/coap_network_udp.dart
+++ b/lib/src/channel/coap_network_udp.dart
@@ -72,7 +72,9 @@ class CoapNetworkUDP implements CoapINetwork {
               if (d.data.isNotEmpty) {
                 _data.add(d.data.toList());
                 buff.addAll(d.data.toList());
-                final rxEvent = CoapDataReceivedEvent(buff, address);
+                final coapAddress =
+                    CoapInternetAddress(d.address.type, d.address);
+                final rxEvent = CoapDataReceivedEvent(buff, coapAddress);
                 _eventBus.fire(rxEvent);
               }
             }

--- a/lib/src/coap_request.dart
+++ b/lib/src/coap_request.dart
@@ -34,7 +34,7 @@ class CoapRequest extends CoapMessage {
   int? get method => _method;
 
   /// Indicates whether this request is a multicast request or not.
-  bool? multicast;
+  bool? get multicast => destination?.address.isMulticast;
 
   Uri? _uri;
 

--- a/lib/src/coap_request.dart
+++ b/lib/src/coap_request.dart
@@ -33,6 +33,15 @@ class CoapRequest extends CoapMessage {
   /// The request method(code)
   int? get method => _method;
 
+  @override
+  int? get type {
+    if (super.type == CoapMessageType.con && (multicast ?? false)) {
+      return CoapMessageType.non;
+    }
+
+    return super.type;
+  }
+
   /// Indicates whether this request is a multicast request or not.
   bool? get multicast => destination?.address.isMulticast;
 

--- a/lib/src/net/coap_matcher.dart
+++ b/lib/src/net/coap_matcher.dart
@@ -237,6 +237,20 @@ class CoapMatcher implements CoapIMatcher {
     final keyToken = CoapKeyToken(response.token);
     final exchange = _exchangesByToken[keyToken];
     if (exchange != null) {
+      if (exchange is CoapMulticastExchange) {
+        _log!.info('Matcher - Received response to multicast '
+            'request ${exchange.request}');
+        if (!exchange.alreadyReceived(response)) {
+          _log!.info('Matcher - Received multicast response is from a new '
+              'endpoint.');
+          exchange.responses.add(response);
+        } else {
+          _log!.info('Matcher - Received multicast response is a duplicate.');
+          response.duplicate = true;
+        }
+        return exchange;
+      }
+
       // There is an exchange with the given token
       final prev = _deduplicator!.findPrevious(keyId, exchange);
       if (prev != null) {

--- a/lib/src/net/coap_multicast_exchange.dart
+++ b/lib/src/net/coap_multicast_exchange.dart
@@ -1,0 +1,23 @@
+/*
+ * Package : Coap
+ * Author : Jan Romann <jan.romann@uni-bremen.de>
+ * Date   : 02/15/2022
+ * Copyright :  Jan Romann
+ */
+
+part of coap;
+
+class CoapMulticastExchange extends CoapExchange {
+  CoapMulticastExchange(CoapRequest? request, CoapOrigin origin,
+      {required namespace})
+      : super(request, origin, namespace: namespace);
+
+  final List<CoapResponse> responses = [];
+
+  bool alreadyReceived(CoapResponse response) {
+    final filteredResponses = responses.where((element) =>
+        element.source?.address.address == response.source?.address.address);
+
+    return filteredResponses.isNotEmpty;
+  }
+}

--- a/lib/src/stack/coap_layer_stack.dart
+++ b/lib/src/stack/coap_layer_stack.dart
@@ -58,8 +58,13 @@ class CoapStackTopLayer extends CoapAbstractLayer {
       CoapINextLayer nextLayer, CoapExchange? exchange, CoapRequest request) {
     var nexchange = exchange;
     if (exchange == null) {
-      nexchange = CoapExchange(request, CoapOrigin.local,
-          namespace: request.eventBus!.namespace);
+      if (request.multicast ?? false) {
+        nexchange = CoapMulticastExchange(request, CoapOrigin.local,
+            namespace: request.eventBus!.namespace);
+      } else {
+        nexchange = CoapExchange(request, CoapOrigin.local,
+            namespace: request.eventBus!.namespace);
+      }
       nexchange.endpoint = request.endpoint;
     }
     nexchange?.request = request;
@@ -86,7 +91,8 @@ class CoapStackTopLayer extends CoapAbstractLayer {
   @override
   void receiveResponse(
       CoapINextLayer nextLayer, CoapExchange exchange, CoapResponse response) {
-    if (!response.hasOption(optionTypeObserve)) {
+    if (!response.hasOption(optionTypeObserve) &&
+        exchange is! CoapMulticastExchange) {
       exchange.complete = true;
     }
     if (exchange.deliverer != null) {


### PR DESCRIPTION
This PR applies a couple of fixes/changes to the project in order to make it possible to use simple (i. e. non-blockwise) multicast requests. To achieve this, multicast requests are no longer being able to be sent as confirmable messages (c. f. [RFC 7252, section 8.1](https://datatracker.ietf.org/doc/html/rfc7252#section-8.1)). Instead, all confirmable multicasts requests are converted to non-confirmable ones. Furthermore, multicast requests are no longer being labelled as complete after the first response and multiple responses no longer marked as duplicates.

I guess the solution is probably not perfect yet (and does not resolve #55 yet), but I guess it is a step into the right direction. Feedback is highly appreciated :) 