### PR TITLE
feat(client): set default `InternetAddressType` to `any`

### DIFF
--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -63,8 +63,8 @@ class CoapClient {
   /// Timeout
   int timeout = 32767; //ms
 
-  /// Address type, set this if using IPV6
-  InternetAddressType addressType = InternetAddressType.IPv4;
+  /// Address type.
+  InternetAddressType addressType = InternetAddressType.any;
 
   /// Tell the client to use Confirmable requests.
   CoapClient useCONs() {


### PR DESCRIPTION
This PR applies a small change to the client by setting the default `addressType` to `InternetAddressType.any` which should make it possible to use both IPv4 and IPv6 addresses by default on most systems.