### PR TITLE
Revert "feat(client): set default `InternetAddressType` to `any`"

### DIFF
--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -63,8 +63,8 @@ class CoapClient {
   /// Timeout
   int timeout = 32767; //ms
 
-  /// Address type.
-  InternetAddressType addressType = InternetAddressType.any;
+  /// Address type, set this if using IPV6
+  InternetAddressType addressType = InternetAddressType.IPv4;
 
   /// Tell the client to use Confirmable requests.
   CoapClient useCONs() {


### PR DESCRIPTION
Reverts shamblett/coap#62

Resolves #63. In order to support both IPv4 and IPv6 by default a different solution seems to be needed. 