### PR TITLE
fix: remove closed UDP channels from CoapNetworkManagement

### DIFF
--- a/example/hello_resource.dart
+++ b/example/hello_resource.dart
@@ -8,7 +8,6 @@
  */
 
 import 'dart:async';
-import 'dart:io';
 import 'package:coap/coap.dart';
 import 'config/coap_config.dart';
 
@@ -45,6 +44,4 @@ FutureOr<void> main(List<String> args) async {
 
   // Clean up
   client.close();
-
-  exit(0);
 }

--- a/example/ping.dart
+++ b/example/ping.dart
@@ -8,7 +8,6 @@
  */
 
 import 'dart:async';
-import 'dart:io';
 import 'package:coap/coap.dart';
 import 'config/coap_config.dart';
 
@@ -44,6 +43,4 @@ FutureOr<void> main(List<String> args) async {
   // Cancel the current request
   print('EXAMPLE  - Cleaning up');
   client.close();
-
-  exit(0);
 }

--- a/example/post_create_resource.dart
+++ b/example/post_create_resource.dart
@@ -8,7 +8,6 @@
  */
 
 import 'dart:async';
-import 'dart:io';
 import 'package:coap/coap.dart';
 import 'config/coap_config.dart';
 
@@ -55,6 +54,4 @@ FutureOr<void> main(List<String> args) async {
 
   // Clean up
   client.close();
-
-  exit(0);
 }

--- a/lib/src/channel/coap_udp_channel.dart
+++ b/lib/src/channel/coap_udp_channel.dart
@@ -40,6 +40,7 @@ class CoapUDPChannel extends CoapIChannel {
 
   @override
   void stop() {
+    CoapNetworkManagement.removeNetwork(_socket);
     _socket.close();
   }
 


### PR DESCRIPTION
Using the library, I noticed that you cannot reuse the same or even a different client for requests to the same endpoint once the first client has been closed. I discovered that this is the case because a closed `CoapUDPChannel` was not being removed from the static list of networks in the `CoapNetworkManagement` class, yet. This PR fixes this issue.

Doing so, I noticed that calling `exit(0)` in some examples is not necessary anymore after the client has been closed. The remaining examples still need the `exit(0)` call, though.