### PR TITLE
fix: override hashCode in CoapInternetAddress

### DIFF
--- a/lib/src/net/coap_internet_address.dart
+++ b/lib/src/net/coap_internet_address.dart
@@ -50,4 +50,7 @@ class CoapInternetAddress {
     }
     return false;
   }
+
+  @override
+  int get hashCode => Object.hash(address, bindAddress);
 }


### PR DESCRIPTION
This change fixes an issue raised by pana that currently prevents the package from getting the full score on [pub.dev](https://pub.dev/packages/coap/score), if I see it correctly. It simply adds an override for the `hashCode` getter in the `CoapInternetAddress` class.

Similar to the overridden `=` operator, the hash code is calculated by combining the hashes of the `address` and the `bindAddress`.