### PR TITLE
refactor: add possibility to support different URI schemes

### DIFF
--- a/lib/src/channel/coap_network_manager.dart
+++ b/lib/src/channel/coap_network_manager.dart
@@ -7,6 +7,18 @@
 
 part of coap;
 
+/// This [Exception] is thrown when an unsupported URI scheme is encountered.
+class UnsupportedProtocolException implements Exception {
+  /// The error message of this [Exception].
+  String get message => 'Unsupported URI scheme $uriScheme encountered.';
+
+  /// The unsupported Uri Scheme that was encountered.
+  final String uriScheme;
+
+  /// Constructor.
+  UnsupportedProtocolException(this.uriScheme);
+}
+
 /// A network management/caching class, allows already
 /// bound endpoints to be reused without instantiating them again.
 class CoapNetworkManagement {
@@ -14,10 +26,21 @@ class CoapNetworkManagement {
 
   /// Gets a new network, otherwise tries to find a cached network
   /// and returns that.
-  static CoapINetwork getNetwork(CoapInternetAddress address, int port,
-      {required String namespace}) {
-    final CoapINetwork network =
-        CoapNetworkUDP(address, port, namespace: namespace);
+  static CoapINetwork getNetwork(
+      CoapInternetAddress address, int port, String scheme,
+      {required String namespace, required DefaultCoapConfig config}) {
+    final CoapINetwork network;
+
+    switch (scheme) {
+      case CoapConstants.uriScheme:
+        {
+          network = CoapNetworkUDP(address, port, namespace: namespace);
+          break;
+        }
+      default:
+        throw UnsupportedProtocolException(scheme);
+    }
+
     if (_networks.contains(network)) {
       return _networks.where((CoapINetwork e) => e == network).toList()[0];
     } else {

--- a/lib/src/channel/coap_udp_channel.dart
+++ b/lib/src/channel/coap_udp_channel.dart
@@ -10,14 +10,20 @@ part of coap;
 /// Channel via UDP protocol.
 class CoapUDPChannel extends CoapIChannel {
   /// Initialise with a specific address and port
-  CoapUDPChannel(this._address, this._port, {required String namespace}) {
+  CoapUDPChannel(this._address, this._port, this.uriScheme,
+      {required String namespace, required this.config}) {
     _eventBus = CoapEventBus(namespace: namespace);
-    final socket =
-        CoapNetworkManagement.getNetwork(address!, _port, namespace: namespace);
-    _socket = socket as CoapNetworkUDP;
+    final socket = CoapNetworkManagement.getNetwork(
+        address!, _port, CoapConstants.uriScheme,
+        namespace: namespace, config: config);
+    _socket = socket;
   }
 
+  final String uriScheme;
+
   final int _port;
+
+  final DefaultCoapConfig config;
 
   @override
   int get port => _port;
@@ -25,7 +31,7 @@ class CoapUDPChannel extends CoapIChannel {
 
   @override
   CoapInternetAddress? get address => _address;
-  late CoapNetworkUDP _socket;
+  late CoapINetwork _socket;
 
   final typed.Uint8Buffer _buff = typed.Uint8Buffer();
 
@@ -47,9 +53,7 @@ class CoapUDPChannel extends CoapIChannel {
   @override
   Future<void> send(typed.Uint8Buffer data,
       [CoapInternetAddress? address]) async {
-    if (_socket.socket != null) {
-      _socket.send(data, address);
-    }
+    _socket.send(data, address);
   }
 
   @override

--- a/lib/src/channel/coap_udp_channel.dart
+++ b/lib/src/channel/coap_udp_channel.dart
@@ -11,13 +11,11 @@ part of coap;
 class CoapUDPChannel extends CoapIChannel {
   /// Initialise with a specific address and port
   CoapUDPChannel(this._address, this._port, this.uriScheme,
-      {required String namespace, required this.config}) {
-    _eventBus = CoapEventBus(namespace: namespace);
-    final socket = CoapNetworkManagement.getNetwork(
-        address!, _port, CoapConstants.uriScheme,
-        namespace: namespace, config: config);
-    _socket = socket;
-  }
+      {required String namespace, required this.config})
+      : _eventBus = CoapEventBus(namespace: namespace),
+        _socket = CoapNetworkManagement.getNetwork(
+            _address!, _port, CoapConstants.uriScheme,
+            namespace: namespace, config: config);
 
   final String uriScheme;
 
@@ -31,11 +29,11 @@ class CoapUDPChannel extends CoapIChannel {
 
   @override
   CoapInternetAddress? get address => _address;
-  late CoapINetwork _socket;
+  final CoapINetwork _socket;
 
   final typed.Uint8Buffer _buff = typed.Uint8Buffer();
 
-  late final CoapEventBus _eventBus;
+  final CoapEventBus _eventBus;
 
   @override
   Future<void> start() async {

--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -317,7 +317,8 @@ class CoapClient {
     if (endpoint != null) {
       return endpoint;
     } else {
-      return CoapEndpointManager.getDefaultEndpoint(request.endpoint!,
+      return CoapEndpointManager.getDefaultEndpoint(
+          request.uri.scheme, request.endpoint!,
           namespace: _namespace);
     }
   }
@@ -331,8 +332,10 @@ class CoapClient {
     await request.resolveDestination(addressType);
     // Endpoint and channel
     CoapEndpointManager.getDefaultSpec();
-    final CoapIChannel channel =
-        CoapUDPChannel(request.destination, uri.port, namespace: _namespace);
+
+    final channel = CoapEndpointManager.determineCoapChannel(
+        uri.scheme, request.destination, uri.port,
+        namespace: _namespace, config: _config);
     if (endpoint != null) {
       request.endpoint = endpoint;
     } else {

--- a/lib/src/coap_config.dart
+++ b/lib/src/coap_config.dart
@@ -26,7 +26,7 @@ abstract class DefaultCoapConfig {
   int defaultPort = CoapConstants.defaultPort;
 
   /// The default CoAP port for secure CoAP communication (coaps).
-  int get defaultSecurePort => CoapConstants.defaultSecurePort;
+  int defaultSecurePort = CoapConstants.defaultSecurePort;
 
   /// The port which HTTP proxy is on.
   int get httpPort => 8080;

--- a/lib/src/specification/coap_ispec.dart
+++ b/lib/src/specification/coap_ispec.dart
@@ -15,6 +15,9 @@ abstract class CoapISpec {
   /// Gets the default CoAP port in this draft.
   int get defaultPort;
 
+  /// Gets the default CoAPS port in this draft.
+  int get defaultSecurePort;
+
   /// Encodes a CoAP message into a bytes array.
   /// Returns the encoded bytes, or null if the message can not be encoded,
   /// i.e. the message is not a Request, a Response or an EmptyMessage.

--- a/lib/src/specification/rfcs/coap_rfc7252.dart
+++ b/lib/src/specification/rfcs/coap_rfc7252.dart
@@ -45,6 +45,9 @@ class CoapRfc7252 implements CoapISpec {
   int get defaultPort => 5683;
 
   @override
+  int get defaultSecurePort => 5684;
+
+  @override
   CoapIMessageEncoder newMessageEncoder() => CoapMessageEncoderRfc7252();
 
   @override


### PR DESCRIPTION
Dealing with the addition of DTLS to the library, I noticed that the current structure of the library does not really allow for differentiating between URI schemes. This PR proposes a new structure that allows for adding additional network and channel types that can be chosen based on the URI scheme that is encountered.

This way, in contrast to what is currently proposed in #35, additional ways of transporting CoAP packets can be defined in their own classes and do not need to be integrated into the UDP channel/network classes. This also makes the library easier to extend with features like CoAP over TCP or CoAP over WebSockets.

Unfortunately, this PR requires #35 to be rebased/adjusted (sorry @Sorunome) but I hope it won't be too much work :/ 