### PR TITLE
feat: change return type of `send` method to `Future<int>`

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -9,3 +9,9 @@ analyzer:
   exclude:
     - 'example/flutter_example/**'
     - '**coap_config**.dart'
+  errors:
+    unawaited_futures: warning
+
+linter:
+  rules:
+    - unawaited_futures

--- a/lib/src/net/coap_endpoint.dart
+++ b/lib/src/net/coap_endpoint.dart
@@ -168,7 +168,7 @@ class CoapEndPoint implements CoapIEndPoint, CoapIOutbox {
     _eventBus.fire(CoapSendingRequestEvent(request));
 
     if (!request.isCancelled) {
-      _socket.send(_serializeRequest(request), request.destination);
+      await _socket.send(_serializeRequest(request), request.destination);
     }
   }
 

--- a/lib/src/network/coap_inetwork.dart
+++ b/lib/src/network/coap_inetwork.dart
@@ -33,7 +33,7 @@ abstract class CoapINetwork {
 
   /// Send, returns the number of bytes sent or null
   /// if not bound.
-  int send(typed.Uint8Buffer data, [CoapInternetAddress? address]);
+  Future<int> send(typed.Uint8Buffer data, [CoapInternetAddress? address]);
 
   /// Starts the receive listener
   void receive();

--- a/lib/src/network/coap_network_udp.dart
+++ b/lib/src/network/coap_network_udp.dart
@@ -43,7 +43,8 @@ class CoapNetworkUDP implements CoapINetwork {
   bool get bound => _bound;
 
   @override
-  int send(typed.Uint8Buffer data, [CoapInternetAddress? address]) {
+  Future<int> send(typed.Uint8Buffer data,
+      [CoapInternetAddress? address]) async {
     if (_bound) {
       _socket?.send(
           data.toList(), address?.address ?? this.address!.address, port);


### PR DESCRIPTION
[Experimenting with adding CoAPS support](https://github.com/shamblett/coap/compare/issue75...namib-project:dtls-new-api?expand=1) to the library, I noticed that my implementation requires an asynchronous `send` method as it might need to reconnect to a server. This PR therefore changes its return type from `int` to `Future<int>`.

This change does not have an effect on the current state of the library, as sending UDP datagrams is a synchronous operation, but lays the foundation for future additions in general. I suppose that TCP might  make use of this change as well.