### PR TITLE
feat!: let failed requests throw Exceptions instead of returning null

### DIFF
--- a/example/cancel_request.dart
+++ b/example/cancel_request.dart
@@ -34,14 +34,14 @@ FutureOr<void> main(List<String> args) async {
     ignoreThisFuture.ignore();
 
     final resp = await helloRespFuture;
-    print('/hello response: ${resp?.payloadString}');
+    print('/hello response: ${resp.payloadString}');
 
     if (cancelThisReq.retransmits > 0) {
       print('Expected 0 retransmits!');
     }
-
-    client.close();
   } catch (e) {
     print('CoAP encountered an exception: $e');
   }
+
+  client.close();
 }

--- a/example/delete_resource.dart
+++ b/example/delete_resource.dart
@@ -24,10 +24,10 @@ FutureOr<void> main(List<String> args) async {
     print('Sending delete /test to ${uri.host}');
     final response = await client.delete('test');
 
-    print('/test response status: ${response?.statusCodeString}');
-
-    client.close();
+    print('/test response status: ${response.statusCodeString}');
   } catch (e) {
     print('CoAP encountered an exception: $e');
   }
+
+  client.close();
 }

--- a/example/discover_resources.dart
+++ b/example/discover_resources.dart
@@ -22,9 +22,9 @@ FutureOr<void> main(List<String> args) async {
 
     print('Discovered resources:');
     links?.forEach(print);
-
-    client.close();
   } catch (e) {
     print('CoAP encountered an exception: $e');
   }
+
+  client.close();
 }

--- a/example/get_blockwise.dart
+++ b/example/get_blockwise.dart
@@ -20,10 +20,10 @@ FutureOr<void> main(List<String> args) async {
     print('Sending get /large to ${uri.host}');
     final response = await client.get('large');
 
-    print('/large response: ${response?.payloadString}');
-
-    client.close();
+    print('/large response: ${response.payloadString}');
   } catch (e) {
     print('CoAP encountered an exception: $e');
   }
+
+  client.close();
 }

--- a/example/get_max_retransmit.dart
+++ b/example/get_max_retransmit.dart
@@ -38,9 +38,9 @@ FutureOr main() async {
     }
 
     print('Response: $resp');
-
-    client.close();
   } catch (e) {
     print('CoAP encountered an exception: $e');
   }
+
+  client.close();
 }

--- a/example/get_observe_async.dart
+++ b/example/get_observe_async.dart
@@ -44,17 +44,17 @@ FutureOr main() async {
     print('Sending get /large to ${uri.host}');
     futures.add(client
         .get('large')
-        .then((resp) => print('/large response: ${resp?.payloadString}')));
+        .then((resp) => print('/large response: ${resp.payloadString}')));
 
     print('Sending get /test to ${uri.host}');
     futures.add(client
         .get('test')
-        .then((resp) => print('/test response: ${resp?.payloadString}')));
+        .then((resp) => print('/test response: ${resp.payloadString}')));
 
     print('Sending get /separate to ${uri.host}');
     futures.add(client
         .get('separate')
-        .then((resp) => print('/separate response: ${resp?.payloadString}')));
+        .then((resp) => print('/separate response: ${resp.payloadString}')));
 
     print('Waiting until get requests are done');
     await Future.wait(futures);
@@ -65,9 +65,9 @@ FutureOr main() async {
     await Future.delayed(Duration(seconds: 20));
 
     await client.cancelObserveProactive(obsNon);
-
-    client.close();
   } catch (e) {
     print('CoAP encountered an exception: $e');
   }
+
+  client.close();
 }

--- a/example/get_resource.dart
+++ b/example/get_resource.dart
@@ -19,19 +19,19 @@ FutureOr<void> main(List<String> args) async {
   try {
     print('Sending get /test to ${uri.host}');
     var response = await client.get('test');
-    print('/test response: ${response?.payloadString}');
+    print('/test response: ${response.payloadString}');
 
     print('Sending get /multi-format (text) to ${uri.host}');
     response = await client.get('multi-format');
-    print('/multi-format (text) response: ${response?.payloadString}');
+    print('/multi-format (text) response: ${response.payloadString}');
 
     print('Sending get /multi-format (xml) to ${uri.host}');
     response =
         await client.get('multi-format', accept: CoapMediaType.applicationXml);
-    print('/multi-format (xml) response: ${response?.payloadString}');
-
-    client.close();
+    print('/multi-format (xml) response: ${response.payloadString}');
   } catch (e) {
     print('CoAP encountered an exception: $e');
   }
+
+  client.close();
 }

--- a/example/get_resource_secure.dart
+++ b/example/get_resource_secure.dart
@@ -39,19 +39,19 @@ FutureOr<void> main(List<String> args) async {
   try {
     print('Sending get /test to ${uri.host}');
     var response = await client.get('test');
-    print('/test response: ${response?.payloadString}');
+    print('/test response: ${response.payloadString}');
 
     print('Sending get /multi-format (text) to ${uri.host}');
     response = await client.get('multi-format');
-    print('/multi-format (text) response: ${response?.payloadString}');
+    print('/multi-format (text) response: ${response.payloadString}');
 
     print('Sending get /multi-format (xml) to ${uri.host}');
     response =
         await client.get('multi-format', accept: CoapMediaType.applicationXml);
-    print('/multi-format (xml) response: ${response?.payloadString}');
-
-    client.close();
+    print('/multi-format (xml) response: ${response.payloadString}');
   } catch (e) {
     print('CoAP encountered an exception: $e');
   }
+
+  client.close();
 }

--- a/example/log_events.dart
+++ b/example/log_events.dart
@@ -29,9 +29,9 @@ FutureOr<void> main(List<String> args) async {
 
     print('Sending post /large-create to ${uri.host}');
     await client.post('large-create', payload: payload, options: [opt]);
-
-    client.close();
   } catch (e) {
     print('CoAP encountered an exception: $e');
   }
+
+  client.close();
 }

--- a/example/multi_client.dart
+++ b/example/multi_client.dart
@@ -26,16 +26,16 @@ FutureOr<void> main(List<String> args) async {
   try {
     print('Sending get /hello to ${uri1.host}');
     var response = await client1.get('hello');
-    print('/hello response: ${response?.payloadString}');
+    print('/hello response: ${response.payloadString}');
 
     print('Sending get /test to ${uri2.host}');
     response = await client2.get('test');
-    print('/test response: ${response?.payloadString}');
-
-    // Clean up
-    client1.close();
-    client2.close();
+    print('/test response: ${response.payloadString}');
   } catch (e) {
     print('CoAP encountered an exception: $e');
   }
+
+  // Clean up
+  client1.close();
+  client2.close();
 }

--- a/example/ping.dart
+++ b/example/ping.dart
@@ -28,9 +28,9 @@ FutureOr<void> main(List<String> args) async {
     } else {
       print('Ping failed');
     }
-
-    client.close();
   } catch (e) {
     print('CoAP encountered an exception: $e');
   }
+
+  client.close();
 }

--- a/example/post_blockwise.dart
+++ b/example/post_blockwise.dart
@@ -27,15 +27,15 @@ FutureOr<void> main(List<String> args) async {
     print('Sending post /large-create to ${uri.host}');
     var response =
         await client.post('large-create', payload: payload, options: [opt]);
-    print('/large-create response status: ${response?.statusCodeString}');
+    print('/large-create response status: ${response.statusCodeString}');
 
     print('Sending get /large-create to ${uri.host}');
     response = await client.get('large-create');
-    print('/large-create response:\n${response?.payloadString}');
-    print('E-Tags : ${response?.etags.join(',')}');
-
-    client.close();
+    print('/large-create response:\n${response.payloadString}');
+    print('E-Tags : ${response.etags.join(',')}');
   } catch (e) {
     print('CoAP encountered an exception: $e');
   }
+
+  client.close();
 }

--- a/example/post_resource.dart
+++ b/example/post_resource.dart
@@ -23,15 +23,15 @@ FutureOr<void> main(List<String> args) async {
     print('Sending post /large-create to ${uri.host}');
     var response = await client.post('large-create',
         options: [opt], payload: 'SJHTestPost');
-    print('/large-create response status: ${response?.statusCodeString}');
+    print('/large-create response status: ${response.statusCodeString}');
 
     print('Sending get /large-create to ${uri.host}');
     response = await client.get('large-create');
-    print('/large-create response: ${response?.payloadString}');
-    print('E-Tags : ${response?.etags.join(',')}');
-
-    client.close();
+    print('/large-create response: ${response.payloadString}');
+    print('E-Tags : ${response.etags.join(',')}');
   } catch (e) {
     print('CoAP encountered an exception: $e');
   }
+
+  client.close();
 }

--- a/example/put_resource.dart
+++ b/example/put_resource.dart
@@ -23,10 +23,10 @@ FutureOr<void> main(List<String> args) async {
     print('Sending put /create1 to ${uri.host}');
     var response =
         await client.put('create1', options: [opt], payload: 'SJHTestPut');
-    print('/create1 response status: ${response?.statusCodeString}');
-
-    client.close();
+    print('/create1 response status: ${response.statusCodeString}');
   } catch (e) {
     print('CoAP encountered an exception: $e');
   }
+
+  client.close();
 }

--- a/example/sync_vs_async.dart
+++ b/example/sync_vs_async.dart
@@ -30,7 +30,7 @@ FutureOr main() async {
     final futures = <Future<void>>[];
     for (var i = 0; i < 10; i++) {
       futures.add(client.get('test').then((resp) {
-        if (resp?.code != CoapCode.content) {
+        if (resp.code != CoapCode.content) {
           print('Request failed!');
         }
       }));
@@ -46,15 +46,15 @@ FutureOr main() async {
     print('Sending 10 sync requests...');
     for (var i = 0; i < 10; i++) {
       final resp = await client.get('test');
-      if (resp?.code != CoapCode.content) {
+      if (resp.code != CoapCode.content) {
         print('Request failed!');
       }
     }
 
     print('10 sync requests took ${stopwatch.elapsedMilliseconds} ms');
-
-    client.close();
   } catch (e) {
     print('CoAP encountered an exception: $e');
   }
+
+  client.close();
 }

--- a/lib/coap.dart
+++ b/lib/coap.dart
@@ -25,6 +25,7 @@ export 'src/deduplication/coap_crop_rotation_deduplicator.dart';
 export 'src/deduplication/coap_ideduplicator.dart';
 export 'src/deduplication/coap_noop_deduplicator.dart';
 export 'src/deduplication/coap_sweep_deduplicator.dart';
+export 'src/exceptions/coap_request_exception.dart';
 export 'src/network/credentials/psk_credentials.dart';
 export 'src/network/credentials/ecdsa_keys.dart';
 

--- a/lib/src/coap_option_type.dart
+++ b/lib/src/coap_option_type.dart
@@ -34,6 +34,11 @@ abstract class UnknownOptionException implements Exception {
 
   /// Constructor.
   UnknownOptionException(this.optionNumber);
+
+  @override
+  String toString() {
+    return '$runtimeType:  Encountered unknown option number $optionNumber';
+  }
 }
 
 /// [Exception] that is thrown when an unknown elective [CoapOption] number is

--- a/lib/src/exceptions/coap_request_exception.dart
+++ b/lib/src/exceptions/coap_request_exception.dart
@@ -1,0 +1,35 @@
+/*
+ * Package : Coap
+ * Author : Jan Romann <jan.romann@uni-bremen.de>
+ * Date   : 05/22/2022
+ * Copyright :  Jan Romann
+ */
+
+/// Generic class for [Exception]s that are thrown when a CoAP request fails.
+abstract class CoapRequestException implements Exception {
+  String get failReason;
+
+  CoapRequestException();
+
+  @override
+  String toString() {
+    return "$runtimeType: $failReason";
+  }
+}
+
+/// This [Exception] is thrown when a CoAP request has timed out.
+class CoapRequestTimeoutException extends CoapRequestException {
+  /// The number of retransmits after which the request timed out.
+  final int retransmits;
+
+  CoapRequestTimeoutException(this.retransmits);
+
+  @override
+  String get failReason => "Request timed out after $retransmits retransmits.";
+}
+
+/// This [Exception] is thrown when a CoAP request has timed out.
+class CoapRequestCancellationException extends CoapRequestException {
+  @override
+  final failReason = "Request has been cancelled.";
+}

--- a/lib/src/network/coap_inetwork.dart
+++ b/lib/src/network/coap_inetwork.dart
@@ -18,33 +18,43 @@ import 'credentials/psk_credentials.dart';
 
 /// This [Exception] is thrown when an unsupported URI scheme is encountered.
 class UnsupportedProtocolException implements Exception {
-  /// The error message of this [Exception].
-  String get message => 'Unsupported URI scheme $uriScheme encountered.';
-
   /// The unsupported Uri Scheme that was encountered.
   final String uriScheme;
 
   /// Constructor.
   UnsupportedProtocolException(this.uriScheme);
+
+  @override
+  String toString() {
+    return '$runtimeType: Unsupported URI scheme $uriScheme encountered.';
+  }
 }
 
 /// This [Exception] is thrown when Credentials for secure CoAP communication
 /// are missing.
 class CoapCredentialsException implements Exception {
-  /// The error message of this [Exception].
-  final String message;
+  final String _message;
 
-  /// Constructor.
-  CoapCredentialsException(this.message);
+  /// Create a new [Exception] that prints out the given [_message].
+  CoapCredentialsException(this._message);
+
+  @override
+  toString() {
+    return "$runtimeType: $_message";
+  }
 }
 
 /// This [Exception] is thrown when a DTLS related problem occurs.
 class CoapDtlsException implements Exception {
-  /// The error message of this [Exception].
-  final String message;
+  final String _message;
 
-  /// Constructor.
-  CoapDtlsException(this.message);
+  /// Create a new [Exception] that prints out the given [_message].
+  CoapDtlsException(this._message);
+
+  @override
+  toString() {
+    return "$runtimeType: $_message";
+  }
 }
 
 /// Abstract networking class, allows different implementations for


### PR DESCRIPTION
This PR is supposed to be merged after #90 and #91.

Working with the new API, I noticed that handling the possible `null` value that is returned when a request fails is not as convenient as when the request simply throws an Exception. This PR therefore proposes yet another API change by introducing two new Exceptions for cancelled and timed out requests, allowing these two cases of errors to be handled differently.

This behavior should also be more similar to the `http` package's client, which also does not return `null` but throws an exception on failed requests (see, for instance, [here](https://github.com/dart-lang/http/blob/87d43798ae0fe7264ecda9d0dbc3e491a2abab65/lib/src/io_client.dart#L26)).

CC @JosefWN 