### PR TITLE
feat!: set URI for each request instead of for the client

### DIFF
--- a/example/cancel_request.dart
+++ b/example/cancel_request.dart
@@ -13,28 +13,29 @@ import 'config/coap_config.dart';
 
 FutureOr<void> main(List<String> args) async {
   final conf = CoapConfig();
-  final uri = Uri(scheme: 'coap', host: 'coap.me', port: conf.defaultPort);
-  final client = CoapClient(uri, conf);
+  final client = CoapClient(conf);
 
-  final cancelThisReq = CoapRequest.newGet();
-  cancelThisReq.addUriPath('doesNotExist');
+  final cancelUri = Uri.parse("coap://coap.me/doesNotExist");
+  final helloUri = Uri.parse("coap://coap.me/hello");
+
+  final cancelThisReq = CoapRequest.newGet(cancelUri);
 
   try {
     // Ensure this request is not also cancelled
-    print('Sending async get /hello to ${uri.host}');
-    final helloRespFuture = client.get('hello');
+    print('Sending async get ${helloUri.path} to ${helloUri.host}');
+    final helloRespFuture = client.get(helloUri);
 
-    print('Sending async get /doesNotExist to ${uri.host}');
+    print('Sending async get ${cancelUri.path} to ${cancelUri.host}');
     final ignoreThisFuture = client.send(cancelThisReq);
 
-    print('Cancelling get /doesNotExist retries');
+    print('Cancelling get ${cancelUri.path} retries');
     client.cancel(cancelThisReq);
 
-    print('Ignoring /doesNotExist response future');
+    print('Ignoring ${cancelUri.path} response future');
     ignoreThisFuture.ignore();
 
     final resp = await helloRespFuture;
-    print('/hello response: ${resp.payloadString}');
+    print('${helloUri.path} response: ${resp.payloadString}');
 
     if (cancelThisReq.retransmits > 0) {
       print('Expected 0 retransmits!');

--- a/example/delete_resource.dart
+++ b/example/delete_resource.dart
@@ -13,16 +13,12 @@ import 'config/coap_config.dart';
 
 FutureOr<void> main(List<String> args) async {
   final conf = CoapConfig();
-  final uri = Uri(
-    scheme: 'coap',
-    host: 'californium.eclipseprojects.io',
-    port: conf.defaultPort,
-  );
-  final client = CoapClient(uri, conf);
+  final uri = Uri.parse("coap://californium.eclipseprojects.io/test");
+  final client = CoapClient(conf);
 
   try {
-    print('Sending delete /test to ${uri.host}');
-    final response = await client.delete('test');
+    print('Sending delete ${uri.path} to ${uri.host}');
+    final response = await client.delete(uri);
 
     print('/test response status: ${response.statusCodeString}');
   } catch (e) {

--- a/example/discover_resources.dart
+++ b/example/discover_resources.dart
@@ -13,12 +13,12 @@ import 'config/coap_config.dart';
 
 FutureOr<void> main(List<String> args) async {
   final conf = CoapConfig();
-  final uri = Uri(scheme: 'coap', host: 'coap.me', port: conf.defaultPort);
-  final client = CoapClient(uri, conf);
+  final uri = Uri.parse("coap://coap.me");
+  final client = CoapClient(conf);
 
   try {
     print('Sending get /discover/.well-known/core to ${uri.host}');
-    final links = await client.discover();
+    final links = await client.discover(uri);
 
     print('Discovered resources:');
     links?.forEach(print);

--- a/example/get_blockwise.dart
+++ b/example/get_blockwise.dart
@@ -13,12 +13,12 @@ import 'config/coap_config.dart';
 
 FutureOr<void> main(List<String> args) async {
   final conf = CoapConfig();
-  final uri = Uri(scheme: 'coap', host: 'coap.me', port: conf.defaultPort);
-  final client = CoapClient(uri, conf);
+  final uri = Uri.parse("coap://coap.me/large");
+  final client = CoapClient(conf);
 
   try {
-    print('Sending get /large to ${uri.host}');
-    final response = await client.get('large');
+    print('Sending get ${uri.path} to ${uri.host}');
+    final response = await client.get(uri);
 
     print('/large response: ${response.payloadString}');
   } catch (e) {

--- a/example/get_max_retransmit.dart
+++ b/example/get_max_retransmit.dart
@@ -13,13 +13,12 @@ import './config/coap_config.dart';
 
 FutureOr main() async {
   final conf = CoapConfig();
-  final uri = Uri(scheme: 'coap', host: 'google.com', port: conf.defaultPort);
-  final client = CoapClient(uri, conf);
+  final uri = Uri.parse("coap://google.com/doesNotExist");
+  final client = CoapClient(conf);
 
   print('maxRetransmit config: ${conf.maxRetransmit}');
 
-  final request = CoapRequest.newGet();
-  request.addUriPath('doesNotExist');
+  final request = CoapRequest.newGet(uri);
   print('maxRetransmit request: ${request.maxRetransmit} (0=config default)');
 
   try {
@@ -27,7 +26,7 @@ FutureOr main() async {
     request.maxRetransmit = 2;
     print('maxRetransmit altered request: ${request.maxRetransmit}');
 
-    print('Sending get /doesNotExist to ${uri.host}');
+    print('Sending get ${uri.path} to ${uri.host}');
     print('Waiting for timeout, this might take a while...');
     final resp = await client.send(request);
 

--- a/example/get_observe_async.dart
+++ b/example/get_observe_async.dart
@@ -13,47 +13,49 @@ import 'config/coap_config.dart';
 
 FutureOr main() async {
   final conf = CoapConfig();
-  final uri = Uri(
-    scheme: 'coap',
-    host: 'californium.eclipseprojects.io',
-    port: conf.defaultPort,
-  );
-  final client = CoapClient(uri, conf);
+  final baseUri = Uri.parse('coap://californium.eclipseprojects.io');
+  final client = CoapClient(conf);
 
   // Create the request for the get request
-  final reqObs = CoapRequest.newGet();
-  reqObs.addUriPath('obs');
+  final obsUri = baseUri.replace(path: "obs");
+  final reqObs = CoapRequest.newGet(obsUri);
 
   try {
-    print('Observing /obs on ${uri.host}');
+    print('Observing ${obsUri.path} on ${baseUri.host}');
     final obs = await client.observe(reqObs);
     obs.stream.listen((e) {
       print('/obs response: ${e.resp.payloadString}');
     });
 
-    final reqObsNon = CoapRequest(CoapCode.get, confirmable: false);
-    reqObsNon.addUriPath('obs-non');
+    final obsNonUri = baseUri.replace(path: "obs-non");
+    final reqObsNon = CoapRequest(obsNonUri, CoapCode.get, confirmable: false);
 
-    print('Observing /obs-non on ${uri.host}');
+    print('Observing ${obsNonUri.path} on ${obsNonUri.host}');
     final obsNon = await client.observe(reqObsNon);
     obsNon.stream.listen((e) {
-      print('/obs-non response: ${e.resp.payloadString}');
+      print('${obsNonUri.path} response: ${e.resp.payloadString}');
     });
 
+    final largeUri = baseUri.replace(path: "large");
+    final testUri = baseUri.replace(path: "test");
+    final separateUri = baseUri.replace(path: "separate");
+
+    print(largeUri);
+
     final futures = <Future<void>>[];
-    print('Sending get /large to ${uri.host}');
+    print('Sending get ${largeUri.path} to ${largeUri.host}');
     futures.add(client
-        .get('large')
+        .get(largeUri)
         .then((resp) => print('/large response: ${resp.payloadString}')));
 
-    print('Sending get /test to ${uri.host}');
+    print('Sending get ${testUri.path} to ${testUri.host}');
     futures.add(client
-        .get('test')
+        .get(testUri)
         .then((resp) => print('/test response: ${resp.payloadString}')));
 
-    print('Sending get /separate to ${uri.host}');
+    print('Sending get ${separateUri.path} to ${separateUri.host}');
     futures.add(client
-        .get('separate')
+        .get(separateUri)
         .then((resp) => print('/separate response: ${resp.payloadString}')));
 
     print('Waiting until get requests are done');

--- a/example/get_resource.dart
+++ b/example/get_resource.dart
@@ -14,20 +14,24 @@ import 'config/coap_config.dart';
 FutureOr<void> main(List<String> args) async {
   final conf = CoapConfig();
   final uri = Uri(scheme: 'coap', host: 'coap.me', port: conf.defaultPort);
-  final client = CoapClient(uri, conf);
+  final client = CoapClient(conf);
 
   try {
+    final testUri = uri.replace(path: 'test');
+
     print('Sending get /test to ${uri.host}');
-    var response = await client.get('test');
+    var response = await client.get(testUri);
     print('/test response: ${response.payloadString}');
 
+    final multiFormatUri = uri.replace(path: 'multi-format');
+
     print('Sending get /multi-format (text) to ${uri.host}');
-    response = await client.get('multi-format');
+    response = await client.get(multiFormatUri);
     print('/multi-format (text) response: ${response.payloadString}');
 
     print('Sending get /multi-format (xml) to ${uri.host}');
     response =
-        await client.get('multi-format', accept: CoapMediaType.applicationXml);
+        await client.get(multiFormatUri, accept: CoapMediaType.applicationXml);
     print('/multi-format (xml) response: ${response.payloadString}');
   } catch (e) {
     print('CoAP encountered an exception: $e');

--- a/example/get_resource_secure.dart
+++ b/example/get_resource_secure.dart
@@ -30,12 +30,12 @@ class DtlsConfig extends DefaultCoapConfig {
 FutureOr<void> main(List<String> args) async {
   final conf = DtlsConfig();
   final uri = Uri.parse("coaps://californium.eclipseprojects.io/test");
-  final client =
-      CoapClient(conf, pskCredentialsCallback: pskCredentialsCallback);
+  final client = CoapClient(conf);
 
   try {
     print('Sending get /test to ${uri.host}');
-    var response = await client.get(uri);
+    var response =
+        await client.get(uri, pskCredentialsCallback: pskCredentialsCallback);
     print('/test response: ${response.payloadString}');
 
     final secondUri = uri.replace(path: 'multi-format');

--- a/example/get_resource_secure.dart
+++ b/example/get_resource_secure.dart
@@ -29,26 +29,25 @@ class DtlsConfig extends DefaultCoapConfig {
 
 FutureOr<void> main(List<String> args) async {
   final conf = DtlsConfig();
-  final uri = Uri(
-      scheme: 'coaps',
-      host: 'californium.eclipseprojects.io',
-      port: conf.defaultSecurePort);
+  final uri = Uri.parse("coaps://californium.eclipseprojects.io/test");
   final client =
-      CoapClient(uri, conf, pskCredentialsCallback: pskCredentialsCallback);
+      CoapClient(conf, pskCredentialsCallback: pskCredentialsCallback);
 
   try {
     print('Sending get /test to ${uri.host}');
-    var response = await client.get('test');
+    var response = await client.get(uri);
     print('/test response: ${response.payloadString}');
 
-    print('Sending get /multi-format (text) to ${uri.host}');
-    response = await client.get('multi-format');
-    print('/multi-format (text) response: ${response.payloadString}');
+    final secondUri = uri.replace(path: 'multi-format');
 
-    print('Sending get /multi-format (xml) to ${uri.host}');
+    print('Sending get ${secondUri.path} (text) to ${secondUri.host}');
+    response = await client.get(secondUri);
+    print('${secondUri.path} (text) response: ${response.payloadString}');
+
+    print('Sending get ${secondUri.path} (xml) to ${secondUri.host}');
     response =
-        await client.get('multi-format', accept: CoapMediaType.applicationXml);
-    print('/multi-format (xml) response: ${response.payloadString}');
+        await client.get(secondUri, accept: CoapMediaType.applicationXml);
+    print('${secondUri.path} (xml) response: ${response.payloadString}');
   } catch (e) {
     print('CoAP encountered an exception: $e');
   }

--- a/example/log_events.dart
+++ b/example/log_events.dart
@@ -14,8 +14,8 @@ import 'utils.dart';
 
 FutureOr<void> main(List<String> args) async {
   final conf = CoapConfig();
-  final uri = Uri(scheme: 'coap', host: 'coap.me', port: conf.defaultPort);
-  final client = CoapClient(uri, conf);
+  final uri = Uri.parse("coap://coap.me/large-create");
+  final client = CoapClient(conf);
 
   final opt = CoapOption.createUriQuery(
       '${CoapLinkFormat.title}=This is an SJH Post request');
@@ -27,8 +27,8 @@ FutureOr<void> main(List<String> args) async {
     print('Listening to the internal request/response event stream');
     client.events.on().listen(print);
 
-    print('Sending post /large-create to ${uri.host}');
-    await client.post('large-create', payload: payload, options: [opt]);
+    print('Sending post ${uri.path} to ${uri.host}');
+    await client.post(uri, payload: payload, options: [opt]);
   } catch (e) {
     print('CoAP encountered an exception: $e');
   }

--- a/example/multi_client.dart
+++ b/example/multi_client.dart
@@ -13,24 +13,21 @@ import 'config/coap_config.dart';
 
 FutureOr<void> main(List<String> args) async {
   final conf1 = CoapConfig();
-  final uri1 = Uri(scheme: 'coap', host: 'coap.me', port: conf1.defaultPort);
-  final client1 = CoapClient(uri1, conf1);
+  final uri1 = Uri.parse("coap://coap.me/hello");
+  final client1 = CoapClient(conf1);
 
   final conf2 = CoapConfig();
-  final uri2 = Uri(
-      scheme: 'coap',
-      host: 'californium.eclipseprojects.io',
-      port: conf2.defaultPort);
-  final client2 = CoapClient(uri2, conf2);
+  final uri2 = Uri.parse("coap://californium.eclipseprojects.io/test");
+  final client2 = CoapClient(conf2);
 
   try {
-    print('Sending get /hello to ${uri1.host}');
-    var response = await client1.get('hello');
-    print('/hello response: ${response.payloadString}');
+    print('Sending get ${uri1.path} to ${uri1.host}');
+    var response = await client1.get(uri1);
+    print('${uri1.path} response: ${response.payloadString}');
 
-    print('Sending get /test to ${uri2.host}');
-    response = await client2.get('test');
-    print('/test response: ${response.payloadString}');
+    print('Sending get ${uri2.path} to ${uri2.host}');
+    response = await client2.get(uri2);
+    print('${uri2.path} response: ${response.payloadString}');
   } catch (e) {
     print('CoAP encountered an exception: $e');
   }

--- a/example/multi_request_one_client.dart
+++ b/example/multi_request_one_client.dart
@@ -1,0 +1,35 @@
+/*
+ * Package : Coap
+ * Author : S. Hamblett <steve.hamblett@linux.com>
+ * Date   : 06/06/2018
+ * Copyright :  S.Hamblett
+ *
+ * One client making a request to two endpoints
+ */
+
+import 'dart:async';
+import 'package:coap/coap.dart';
+import 'config/coap_config.dart';
+
+FutureOr<void> main(List<String> args) async {
+  final conf = CoapConfig();
+  final client = CoapClient(conf);
+
+  final uri1 = Uri.parse("coap://coap.me/hello");
+  final uri2 = Uri.parse("coap://californium.eclipseprojects.io/test");
+
+  try {
+    print('Sending get ${uri1.path} to ${uri1.host}');
+    var response = await client.get(uri1);
+    print('${uri1.path} response: ${response.payloadString}');
+
+    print('Sending get ${uri2.path} to ${uri2.host}');
+    response = await client.get(uri2);
+    print('${uri2.path} response: ${response.payloadString}');
+  } catch (e) {
+    print('CoAP encountered an exception: $e');
+  }
+
+  // Clean up
+  client.close();
+}

--- a/example/ping.dart
+++ b/example/ping.dart
@@ -13,16 +13,12 @@ import 'config/coap_config.dart';
 
 FutureOr<void> main(List<String> args) async {
   final conf = CoapConfig();
-  final uri = Uri(
-    scheme: 'coap',
-    host: 'californium.eclipseprojects.io',
-    port: conf.defaultPort,
-  );
-  final client = CoapClient(uri, conf);
+  final uri = Uri.parse("coap://californium.eclipseprojects.io");
+  final client = CoapClient(conf);
 
   try {
     print('Pinging client on ${uri.host}');
-    final ok = await client.ping();
+    final ok = await client.ping(uri);
     if (ok) {
       print('Ping successful');
     } else {

--- a/example/post_blockwise.dart
+++ b/example/post_blockwise.dart
@@ -14,8 +14,8 @@ import 'utils.dart';
 
 FutureOr<void> main(List<String> args) async {
   final conf = CoapConfig();
-  final uri = Uri(scheme: 'coap', host: 'coap.me', port: conf.defaultPort);
-  final client = CoapClient(uri, conf);
+  final uri = Uri.parse("coap://coap.me/large-create");
+  final client = CoapClient(conf);
 
   final opt = CoapOption.createUriQuery(
       '${CoapLinkFormat.title}=This is an SJH Post request');
@@ -24,14 +24,13 @@ FutureOr<void> main(List<String> args) async {
   final payload = getRandomString(length: 2000);
 
   try {
-    print('Sending post /large-create to ${uri.host}');
-    var response =
-        await client.post('large-create', payload: payload, options: [opt]);
-    print('/large-create response status: ${response.statusCodeString}');
+    print('Sending post ${uri.path} to ${uri.host}');
+    var response = await client.post(uri, payload: payload, options: [opt]);
+    print('${uri.path} response status: ${response.statusCodeString}');
 
-    print('Sending get /large-create to ${uri.host}');
-    response = await client.get('large-create');
-    print('/large-create response:\n${response.payloadString}');
+    print('Sending get ${uri.path} to ${uri.host}');
+    response = await client.get(uri);
+    print('${uri.path} response:\n${response.payloadString}');
     print('E-Tags : ${response.etags.join(',')}');
   } catch (e) {
     print('CoAP encountered an exception: $e');

--- a/example/post_resource.dart
+++ b/example/post_resource.dart
@@ -13,21 +13,21 @@ import 'config/coap_config.dart';
 
 FutureOr<void> main(List<String> args) async {
   final conf = CoapConfig();
-  final uri = Uri(scheme: 'coap', host: 'coap.me', port: conf.defaultPort);
-  final client = CoapClient(uri, conf);
+  final uri = Uri.parse("coap://coap.me/large-create");
+  final client = CoapClient(conf);
 
   final opt = CoapOption.createUriQuery(
       '${CoapLinkFormat.title}=This is an SJH Post request');
 
   try {
-    print('Sending post /large-create to ${uri.host}');
-    var response = await client.post('large-create',
-        options: [opt], payload: 'SJHTestPost');
-    print('/large-create response status: ${response.statusCodeString}');
+    print('Sending post ${uri.path} to ${uri.host}');
+    var response =
+        await client.post(uri, options: [opt], payload: 'SJHTestPost');
+    print('${uri.path} response status: ${response.statusCodeString}');
 
-    print('Sending get /large-create to ${uri.host}');
-    response = await client.get('large-create');
-    print('/large-create response: ${response.payloadString}');
+    print('Sending get ${uri.path} to ${uri.host}');
+    response = await client.get(uri);
+    print('${uri.path} response: ${response.payloadString}');
     print('E-Tags : ${response.etags.join(',')}');
   } catch (e) {
     print('CoAP encountered an exception: $e');

--- a/example/put_resource.dart
+++ b/example/put_resource.dart
@@ -13,17 +13,16 @@ import 'config/coap_config.dart';
 
 FutureOr<void> main(List<String> args) async {
   final conf = CoapConfig();
-  final uri = Uri(scheme: 'coap', host: 'coap.me', port: conf.defaultPort);
-  final client = CoapClient(uri, conf);
+  final uri = Uri.parse("coap://coap.me/create1");
+  final client = CoapClient(conf);
 
   final opt = CoapOption.createUriQuery(
       '${CoapLinkFormat.title}=This is an SJH Put request');
 
   try {
-    print('Sending put /create1 to ${uri.host}');
-    var response =
-        await client.put('create1', options: [opt], payload: 'SJHTestPut');
-    print('/create1 response status: ${response.statusCodeString}');
+    print('Sending put ${uri.path} to ${uri.host}');
+    var response = await client.put(uri, options: [opt], payload: 'SJHTestPut');
+    print('${uri.path} response status: ${response.statusCodeString}');
   } catch (e) {
     print('CoAP encountered an exception: $e');
   }

--- a/example/sync_vs_async.dart
+++ b/example/sync_vs_async.dart
@@ -13,23 +13,19 @@ import 'config/coap_config.dart';
 
 FutureOr main() async {
   final conf = CoapConfig();
-  final uri = Uri(
-    scheme: 'coap',
-    host: 'californium.eclipseprojects.io',
-    port: conf.defaultPort,
-  );
-  final client = CoapClient(uri, conf);
+  final uri = Uri.parse("coap://coap.me/test");
+  final client = CoapClient(conf);
 
   try {
     // Warm up (create socket etc.)
-    await client.get('test');
+    await client.get(uri);
 
     Stopwatch stopwatch = Stopwatch()..start();
 
     print('Sending 10 async requests...');
     final futures = <Future<void>>[];
     for (var i = 0; i < 10; i++) {
-      futures.add(client.get('test').then((resp) {
+      futures.add(client.get(uri).then((resp) {
         if (resp.code != CoapCode.content) {
           print('Request failed!');
         }
@@ -45,7 +41,7 @@ FutureOr main() async {
 
     print('Sending 10 sync requests...');
     for (var i = 0; i < 10; i++) {
-      final resp = await client.get('test');
+      final resp = await client.get(uri);
       if (resp.code != CoapCode.content) {
         print('Request failed!');
       }

--- a/lib/src/coap_observe_client_relation.dart
+++ b/lib/src/coap_observe_client_relation.dart
@@ -40,7 +40,9 @@ class CoapObserveClientRelation {
   /// Create a cancellation request
   @protected
   CoapRequest newCancel() {
-    final cancel = CoapRequest.newGet(_request.uri);
+    final cancel = CoapRequest.newGet(_request.uri,
+        ecdsaKeys: _request.ecdsaKeys,
+        pskCredentialsCallback: _request.pskCredentialsCallback);
     // Copy options, but set Observe to cancel
     cancel.setOptions(_request.getAllOptions());
     cancel.observe = 1;

--- a/lib/src/coap_observe_client_relation.dart
+++ b/lib/src/coap_observe_client_relation.dart
@@ -40,7 +40,7 @@ class CoapObserveClientRelation {
   /// Create a cancellation request
   @protected
   CoapRequest newCancel() {
-    final cancel = CoapRequest.newGet();
+    final cancel = CoapRequest.newGet(_request.uri);
     // Copy options, but set Observe to cancel
     cancel.setOptions(_request.getAllOptions());
     cancel.observe = 1;

--- a/lib/src/coap_request.dart
+++ b/lib/src/coap_request.dart
@@ -14,6 +14,8 @@ import 'coap_constants.dart';
 import 'coap_message.dart';
 import 'coap_message_type.dart';
 import 'net/coap_iendpoint.dart';
+import 'network/credentials/ecdsa_keys.dart';
+import 'network/credentials/psk_credentials.dart';
 
 /// This class describes the functionality of a CoAP Request as
 /// a subclass of a CoAP Message. It provides:
@@ -23,8 +25,13 @@ import 'net/coap_iendpoint.dart';
 class CoapRequest extends CoapMessage {
   /// Initializes a request message.
   /// Defaults to confirmable
-  CoapRequest(Uri uri, int code, {bool confirmable = true})
-      : super(
+  CoapRequest(
+    Uri uri,
+    int code, {
+    bool confirmable = true,
+    this.ecdsaKeys,
+    this.pskCredentialsCallback,
+  }) : super(
             code: code,
             type: confirmable ? CoapMessageType.con : CoapMessageType.non) {
     this.uri = uri;
@@ -32,6 +39,13 @@ class CoapRequest extends CoapMessage {
 
   /// The request method(code)
   int get method => super.code;
+
+  /// Raw Public Keys for CoAPS with tinyDtls.
+  final EcdsaKeys? ecdsaKeys;
+
+  /// Callback for providing [PskCredentials] (combination of a Pre-shared Key
+  /// and an Identity) for DTLS, optionally based on an Identity Hint.
+  final PskCredentialsCallback? pskCredentialsCallback;
 
   @override
   int get type {
@@ -100,15 +114,38 @@ class CoapRequest extends CoapMessage {
   String toString() => '\n<<< Request Message >>>${super.toString()}';
 
   /// Construct a GET request.
-  static CoapRequest newGet(Uri uri) => CoapRequest(uri, CoapCode.methodGET);
+  static CoapRequest newGet(
+    Uri uri, {
+    EcdsaKeys? ecdsaKeys,
+    PskCredentialsCallback? pskCredentialsCallback,
+  }) =>
+      CoapRequest(uri, CoapCode.methodGET,
+          ecdsaKeys: ecdsaKeys, pskCredentialsCallback: pskCredentialsCallback);
 
   /// Construct a POST request.
-  static CoapRequest newPost(Uri uri) => CoapRequest(uri, CoapCode.methodPOST);
+  static CoapRequest newPost(
+    Uri uri, {
+    EcdsaKeys? ecdsaKeys,
+    PskCredentialsCallback? pskCredentialsCallback,
+  }) =>
+      CoapRequest(uri, CoapCode.methodPOST,
+          ecdsaKeys: ecdsaKeys, pskCredentialsCallback: pskCredentialsCallback);
 
   /// Construct a PUT request.
-  static CoapRequest newPut(Uri uri) => CoapRequest(uri, CoapCode.methodPUT);
+  static CoapRequest newPut(
+    Uri uri, {
+    EcdsaKeys? ecdsaKeys,
+    PskCredentialsCallback? pskCredentialsCallback,
+  }) =>
+      CoapRequest(uri, CoapCode.methodPUT,
+          ecdsaKeys: ecdsaKeys, pskCredentialsCallback: pskCredentialsCallback);
 
   /// Construct a DELETE request.
-  static CoapRequest newDelete(Uri uri) =>
-      CoapRequest(uri, CoapCode.methodDELETE);
+  static CoapRequest newDelete(
+    Uri uri, {
+    EcdsaKeys? ecdsaKeys,
+    PskCredentialsCallback? pskCredentialsCallback,
+  }) =>
+      CoapRequest(uri, CoapCode.methodDELETE,
+          ecdsaKeys: ecdsaKeys, pskCredentialsCallback: pskCredentialsCallback);
 }

--- a/lib/src/coap_request.dart
+++ b/lib/src/coap_request.dart
@@ -23,10 +23,12 @@ import 'net/coap_iendpoint.dart';
 class CoapRequest extends CoapMessage {
   /// Initializes a request message.
   /// Defaults to confirmable
-  CoapRequest(int code, {bool confirmable = true})
+  CoapRequest(Uri uri, int code, {bool confirmable = true})
       : super(
             code: code,
-            type: confirmable ? CoapMessageType.con : CoapMessageType.non);
+            type: confirmable ? CoapMessageType.con : CoapMessageType.non) {
+    this.uri = uri;
+  }
 
   /// The request method(code)
   int get method => super.code;
@@ -98,14 +100,15 @@ class CoapRequest extends CoapMessage {
   String toString() => '\n<<< Request Message >>>${super.toString()}';
 
   /// Construct a GET request.
-  static CoapRequest newGet() => CoapRequest(CoapCode.methodGET);
+  static CoapRequest newGet(Uri uri) => CoapRequest(uri, CoapCode.methodGET);
 
   /// Construct a POST request.
-  static CoapRequest newPost() => CoapRequest(CoapCode.methodPOST);
+  static CoapRequest newPost(Uri uri) => CoapRequest(uri, CoapCode.methodPOST);
 
   /// Construct a PUT request.
-  static CoapRequest newPut() => CoapRequest(CoapCode.methodPUT);
+  static CoapRequest newPut(Uri uri) => CoapRequest(uri, CoapCode.methodPUT);
 
   /// Construct a DELETE request.
-  static CoapRequest newDelete() => CoapRequest(CoapCode.methodDELETE);
+  static CoapRequest newDelete(Uri uri) =>
+      CoapRequest(uri, CoapCode.methodDELETE);
 }

--- a/lib/src/codec/coap_imessage_decoder.dart
+++ b/lib/src/codec/coap_imessage_decoder.dart
@@ -34,7 +34,7 @@ abstract class CoapIMessageDecoder {
   int? get id;
 
   /// Decodes as a Request.
-  CoapRequest? decodeRequest();
+  CoapRequest? decodeRequest(Uri requestUri);
 
   /// Decodes as a Response.
   CoapResponse? decodeResponse();
@@ -43,5 +43,5 @@ abstract class CoapIMessageDecoder {
   CoapEmptyMessage? decodeEmptyMessage();
 
   /// Decodes as a CoAP message.
-  CoapMessage? decodeMessage();
+  CoapMessage? decodeMessage(Uri requestUri);
 }

--- a/lib/src/codec/decoders/coap_message_decoder.dart
+++ b/lib/src/codec/decoders/coap_message_decoder.dart
@@ -49,9 +49,9 @@ abstract class CoapMessageDecoder implements CoapIMessageDecoder {
   bool get isEmpty => code == CoapCode.empty;
 
   @override
-  CoapRequest? decodeRequest() {
+  CoapRequest? decodeRequest(Uri requestUri) {
     if (isRequest) {
-      final request = CoapRequest(code);
+      final request = CoapRequest(requestUri, code);
       request.type = type;
       request.id = id;
       parseMessage(request);
@@ -85,9 +85,9 @@ abstract class CoapMessageDecoder implements CoapIMessageDecoder {
   }
 
   @override
-  CoapMessage? decodeMessage() {
+  CoapMessage? decodeMessage(Uri uri) {
     if (isRequest) {
-      return decodeRequest();
+      return decodeRequest(uri);
     } else if (isResponse) {
       return decodeResponse();
     } else if (isEmpty) {

--- a/lib/src/event/coap_event_bus.dart
+++ b/lib/src/event/coap_event_bus.dart
@@ -144,13 +144,15 @@ enum CoapOrigin {
 /// Data received Event
 class CoapDataReceivedEvent {
   /// Construction
-  CoapDataReceivedEvent(this.data, this.address);
+  CoapDataReceivedEvent(this.data, this.address, this.uriScheme);
 
   /// The data
   Uint8Buffer data;
 
   /// The address
   CoapInternetAddress address;
+
+  final String uriScheme;
 
   @override
   String toString() => '$runtimeType:\n$data from ${address.address}';

--- a/lib/src/net/coap_endpoint.dart
+++ b/lib/src/net/coap_endpoint.dart
@@ -124,7 +124,8 @@ class CoapEndPoint implements CoapIEndPoint, CoapIOutbox {
     if (decoder.isRequest) {
       CoapRequest? request;
       try {
-        request = decoder.decodeRequest();
+        Uri uri = event.address.toUri()..replace(scheme: event.uriScheme);
+        request = decoder.decodeRequest(uri);
       } on Exception {
         if (!decoder.isReply) {
           // Manually build RST from raw information

--- a/lib/src/net/coap_internet_address.dart
+++ b/lib/src/net/coap_internet_address.dart
@@ -39,4 +39,8 @@ class CoapInternetAddress {
       return ipv6DefaultBind;
     }
   }
+
+  Uri toUri() {
+    return Uri(host: address.host);
+  }
 }

--- a/lib/src/network/coap_network_openssl.dart
+++ b/lib/src/network/coap_network_openssl.dart
@@ -12,6 +12,7 @@ import 'dart:typed_data';
 import 'package:dtls/dtls.dart';
 import 'package:typed_data/typed_data.dart';
 
+import '../coap_constants.dart';
 import '../event/coap_event_bus.dart';
 import '../net/coap_internet_address.dart';
 import 'coap_inetwork.dart';
@@ -43,7 +44,8 @@ class CoapNetworkOpenSSL implements CoapINetwork {
     final buff = Uint8Buffer();
     if (frame.isNotEmpty) {
       buff.addAll(frame.toList());
-      final rxEvent = CoapDataReceivedEvent(buff, address);
+      final rxEvent =
+          CoapDataReceivedEvent(buff, address, CoapConstants.secureUriScheme);
       _eventBus.fire(rxEvent);
     }
   }

--- a/lib/src/network/coap_network_tinydtls.dart
+++ b/lib/src/network/coap_network_tinydtls.dart
@@ -8,6 +8,7 @@
 import 'package:dart_tinydtls/dart_tinydtls.dart';
 import 'package:typed_data/typed_data.dart';
 
+import '../coap_constants.dart';
 import '../event/coap_event_bus.dart';
 import '../net/coap_internet_address.dart';
 import 'coap_inetwork.dart';
@@ -125,7 +126,8 @@ class CoapNetworkTinyDtls implements CoapINetwork {
         buff.addAll(datagram.data.toList());
         final coapAddress =
             CoapInternetAddress(datagram.address.type, datagram.address);
-        final rxEvent = CoapDataReceivedEvent(buff, coapAddress);
+        final rxEvent = CoapDataReceivedEvent(
+            buff, coapAddress, CoapConstants.secureUriScheme);
         _eventBus.fire(rxEvent);
       }
     });

--- a/lib/src/network/coap_network_udp.dart
+++ b/lib/src/network/coap_network_udp.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 
 import 'package:typed_data/typed_data.dart';
 
+import '../coap_constants.dart';
 import '../event/coap_event_bus.dart';
 import '../net/coap_internet_address.dart';
 import 'coap_inetwork.dart';
@@ -65,7 +66,8 @@ class CoapNetworkUDP implements CoapINetwork {
               buff.addAll(d.data.toList());
               final coapAddress =
                   CoapInternetAddress(d.address.type, d.address);
-              _eventBus.fire(CoapDataReceivedEvent(buff, coapAddress));
+              _eventBus.fire(CoapDataReceivedEvent(
+                  buff, coapAddress, CoapConstants.uriScheme));
             }
           }
           break;

--- a/lib/src/specification/coap_ispec.dart
+++ b/lib/src/specification/coap_ispec.dart
@@ -30,7 +30,7 @@ abstract class CoapISpec {
   /// Decodes a CoAP message from a bytes array.
   /// Returns the decoded message, or null if the bytes array
   /// can not be recognized.
-  CoapMessage? decode(Uint8Buffer bytes);
+  CoapMessage? decode(Uint8Buffer bytes, Uri uri);
 
   /// Gets an IMessageEncoder.
   CoapIMessageEncoder newMessageEncoder();

--- a/lib/src/specification/rfcs/coap_rfc7252.dart
+++ b/lib/src/specification/rfcs/coap_rfc7252.dart
@@ -65,8 +65,8 @@ class CoapRfc7252 implements CoapISpec {
       newMessageEncoder().encodeMessage(msg);
 
   @override
-  CoapMessage? decode(Uint8Buffer bytes) =>
-      newMessageDecoder(bytes).decodeMessage();
+  CoapMessage? decode(Uint8Buffer bytes, Uri uri) =>
+      newMessageDecoder(bytes).decodeMessage(uri);
 
   /// Calculates the value used in the extended option fields as specified
   /// in RFC 7252, section 3.1.

--- a/lib/src/stack/coap_blockwise_layer.dart
+++ b/lib/src/stack/coap_blockwise_layer.dart
@@ -119,7 +119,7 @@ class CoapBlockwiseLayer extends CoapAbstractLayer {
           _earlyBlock2Negotiation(exchange, request);
 
           // Assemble and deliver
-          final assembled = CoapRequest(request.method);
+          final assembled = CoapRequest(request.uri, request.method);
           _assembleMessage(status, assembled, request);
 
           exchange.request = assembled;
@@ -303,7 +303,7 @@ class CoapBlockwiseLayer extends CoapAbstractLayer {
           final szx = block2.szx;
           final m = block2.m;
 
-          final block = CoapRequest(request.method);
+          final block = CoapRequest(request.uri, request.method);
           block.endpoint = request.endpoint;
           // NON could make sense over SMS or similar transports
           block.type = request.type;
@@ -388,7 +388,7 @@ class CoapBlockwiseLayer extends CoapAbstractLayer {
       CoapRequest request, CoapBlockwiseStatus status) {
     final num = status.currentNUM;
     final szx = status.currentSZX;
-    final block = CoapRequest(request.method);
+    final block = CoapRequest(request.uri, request.method);
     block.endpoint = request.endpoint;
     block.setOptions(request.getAllOptions());
     block.destination = request.destination;

--- a/lib/src/stack/coap_observe_layer.dart
+++ b/lib/src/stack/coap_observe_layer.dart
@@ -50,7 +50,7 @@ class CoapReregistrationContext {
   void _timerElapsed() {
     final request = _exchange.request!;
     if (!request.isCancelled) {
-      final refresh = CoapRequest.newGet();
+      final refresh = CoapRequest.newGet(request.uri);
       refresh.setOptions(request.getAllOptions());
       // Make sure Observe is set and zero
       refresh.observe = 0;

--- a/test/coap_message_encode_decode_test.dart
+++ b/test/coap_message_encode_decode_test.dart
@@ -171,13 +171,13 @@ void main() {
 
     void testMessage(CoapISpec spec, int testNo) {
       final CoapMessage msg =
-          CoapRequest(CoapCode.methodGET, confirmable: true);
+          CoapRequest(Uri(), CoapCode.methodGET, confirmable: true);
 
       msg.id = 12345;
       msg.payload = typed.Uint8Buffer()..addAll('payload'.codeUnits);
       final data = spec.encode(msg)!;
       checkData(spec.name, data, testNo);
-      final convMsg = spec.decode(data)!;
+      final convMsg = spec.decode(data, Uri())!;
       expect(msg.code, convMsg.code);
       expect(msg.type, convMsg.type);
       expect(msg.id, convMsg.id);
@@ -189,7 +189,7 @@ void main() {
 
     void testMessageWithOptions(CoapISpec spec, int testNo) {
       final CoapMessage msg =
-          CoapRequest(CoapCode.methodGET, confirmable: true);
+          CoapRequest(Uri(), CoapCode.methodGET, confirmable: true);
 
       msg.id = 12345;
       msg.payload = typed.Uint8Buffer()..addAll('payload'.codeUnits);
@@ -200,7 +200,7 @@ void main() {
       expect(msg.getFirstOption(OptionType.maxAge)!.value, 30);
       final data = spec.encode(msg)!;
       checkData(spec.name, data, testNo);
-      final convMsg = spec.decode(data)!;
+      final convMsg = spec.decode(data, Uri())!;
 
       expect(msg.code, convMsg.code);
       expect(msg.type, convMsg.type);
@@ -219,7 +219,7 @@ void main() {
 
     void testMessageWithExtendedOption(CoapISpec spec, int testNo) {
       final CoapMessage msg =
-          CoapRequest(CoapCode.methodGET, confirmable: true);
+          CoapRequest(Uri(), CoapCode.methodGET, confirmable: true);
 
       msg.id = 12345;
       msg.addOption(CoapOption.createVal(OptionType.contentFormat, 0));
@@ -228,7 +228,7 @@ void main() {
 
       final data = spec.encode(msg)!;
       checkData(spec.name, data, testNo);
-      final convMsg = spec.decode(data)!;
+      final convMsg = spec.decode(data, Uri())!;
 
       expect(msg.code, convMsg.code);
       expect(msg.type, convMsg.type);
@@ -244,7 +244,8 @@ void main() {
     }
 
     void testRequestParsing(CoapISpec spec, int testNo) {
-      final request = CoapRequest(CoapCode.methodPOST, confirmable: false);
+      final request =
+          CoapRequest(Uri(), CoapCode.methodPOST, confirmable: false);
       request.id = 7;
       request.token = typed.Uint8Buffer()..addAll(<int>[11, 82, 165, 77, 3]);
       request
@@ -259,7 +260,7 @@ void main() {
       final decoder = spec.newMessageDecoder(bytes);
       expect(decoder.isRequest, isTrue);
 
-      final result = decoder.decodeRequest()!;
+      final result = decoder.decodeRequest(Uri())!;
       expect(request.id, result.id);
       expect(
           leq.equals(request.token!.toList(), result.token!.toList()), isTrue);


### PR DESCRIPTION
This PR depends on #92 and is supposed to be merged after it.

Here, I wanted to make another proposal for a major overhaul of the API, moving the indication of the request URI to the request itself, making it possible to reuse one client for multiple requests to different servers. This makes the handling of the client more intuitive in my opinion, should enhance the performance, and also aligns the library a bit more with the `http` library.