### PR TITLE
refactor: refactor CoapOption creation using factory constructors

### DIFF
--- a/lib/src/coap_option.dart
+++ b/lib/src/coap_option.dart
@@ -141,9 +141,7 @@ class CoapOption {
   String toString() => '$name: ${_toValueString()}';
 
   /// Creates an option.
-  // ignore: prefer_constructors_over_static_methods
-  static CoapOption create(final int optionNumber) {
-    final type = OptionType.fromTypeNumber(optionNumber);
+  factory CoapOption.create(final OptionType type) {
     if (type == OptionType.block1 || type == OptionType.block2) {
       return CoapBlockOption(type);
     }
@@ -151,20 +149,20 @@ class CoapOption {
   }
 
   /// Creates an option.
-  static CoapOption createRaw(final OptionType type, final Uint8Buffer raw) =>
-      create(type.optionNumber)..byteValue = raw;
+  factory CoapOption.createRaw(final OptionType type, final Uint8Buffer raw) =>
+      CoapOption.create(type)..byteValue = raw;
 
   /// Creates an option.
-  static CoapOption createString(final OptionType type, final String str) =>
-      create(type.optionNumber)..stringValue = str;
+  factory CoapOption.createString(final OptionType type, final String str) =>
+      CoapOption.create(type)..stringValue = str;
 
   /// Creates a query option (shorthand because it's so common).
-  static CoapOption createUriQuery(final String str) =>
-      create(OptionType.uriQuery.optionNumber)..stringValue = str;
+  factory CoapOption.createUriQuery(final String str) =>
+      CoapOption.create(OptionType.uriQuery)..stringValue = str;
 
   /// Creates an option.
-  static CoapOption createVal(final OptionType type, final int val) =>
-      create(type.optionNumber)..intValue = val;
+  factory CoapOption.createVal(final OptionType type, final int val) =>
+      CoapOption.create(type)..intValue = val;
 
   /// Splits a string into a set of options, e.g. a uri path.
   /// Remove any leading /

--- a/lib/src/codec/decoders/coap_message_decoder_rfc7252.dart
+++ b/lib/src/codec/decoders/coap_message_decoder_rfc7252.dart
@@ -96,7 +96,8 @@ class CoapMessageDecoder18 extends CoapMessageDecoder {
         // Read option
         final CoapOption opt;
         try {
-          opt = CoapOption.create(currentOption);
+          final optionType = OptionType.fromTypeNumber(currentOption);
+          opt = CoapOption.create(optionType);
         } on UnknownElectiveOptionException {
           // Unknown elective options must be silently ignored
           continue;

--- a/test/coap_message_api_test.dart
+++ b/test/coap_message_api_test.dart
@@ -48,11 +48,11 @@ void main() {
     final message = CoapMessage();
     final opt1 = CoapOption(OptionType.uriHost);
     expect(
-      () => CoapOption.create(9000),
+      () => CoapOption.create(OptionType.fromTypeNumber(9000)),
       throwsA(const TypeMatcher<UnknownElectiveOptionException>()),
     );
     expect(
-      () => CoapOption.create(9001),
+      () => CoapOption.create(OptionType.fromTypeNumber(9001)),
       throwsA(const TypeMatcher<UnknownCriticalOptionException>()),
     );
     final options = <CoapOption>[

--- a/test/coap_option_test.dart
+++ b/test/coap_option_test.dart
@@ -54,7 +54,7 @@ void main() {
     });
 
     test('Name', () {
-      final opt = CoapOption.create(15);
+      final opt = CoapOption.create(OptionType.fromTypeNumber(15));
       expect(opt.name, 'Uri-Query');
     });
 
@@ -96,7 +96,8 @@ void main() {
     });
 
     test('Set string value', () {
-      final option = CoapOption.create(11)..stringValue = '';
+      final option = CoapOption.create(OptionType.fromTypeNumber(11))
+        ..stringValue = '';
       expect(option.length, 0);
 
       option.stringValue = 'CoAP.NET';
@@ -104,7 +105,8 @@ void main() {
     });
 
     test('Set int value', () {
-      final option = CoapOption.create(12)..intValue = 0;
+      final option = CoapOption.create(OptionType.fromTypeNumber(12))
+        ..intValue = 0;
       expect(option.byteValue[0], 0);
 
       option.intValue = 11;


### PR DESCRIPTION
This PR applies some minor refactorings to the creation of CoapOptions, getting rid of the `ignore: prefer_constructors_over_static_methods` comment.