### PR TITLE
chore: upgrade dart_tinydtls to version 2.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   build: '^2.2.1'
   collection: '^1.15.0'
-  dart_tinydtls: ^1.0.0
+  dart_tinydtls: ^2.0.0
   dtls: ^0.1.0
   event_bus: '^2.0.0'
   executor: '^2.2.2'


### PR DESCRIPTION
This PR updates `dart_tinydtls` to the latest major version.