### PR TITLE
fix: add missing export for CoapResponse

### DIFF
--- a/lib/coap.dart
+++ b/lib/coap.dart
@@ -27,6 +27,7 @@ export 'src/coap_message_type.dart';
 export 'src/coap_option.dart';
 export 'src/coap_option_type.dart';
 export 'src/coap_request.dart';
+export 'src/coap_response.dart';
 export 'src/deduplication/coap_crop_rotation_deduplicator.dart';
 export 'src/deduplication/coap_ideduplicator.dart';
 export 'src/deduplication/coap_noop_deduplicator.dart';


### PR DESCRIPTION
With #90 merged and the new version released, I noticed that `CoapResponse` should also be exported. Would be great if this could become part of a patch release, @shamblett :) Did you notice any other exports missing, @JosefWN?