### PR TITLE
fix: change identifier of OptionType name field

### DIFF
--- a/lib/src/coap_option.dart
+++ b/lib/src/coap_option.dart
@@ -95,7 +95,7 @@ class CoapOption {
   }
 
   /// Gets the name of the option that corresponds to its type.
-  String get name => _type.name;
+  String get name => _type.optionName;
 
   /// Gets the value's length in bytes of the option.
   int get length => _buffer.lengthInBytes;

--- a/lib/src/coap_option_type.dart
+++ b/lib/src/coap_option_type.dart
@@ -108,11 +108,11 @@ enum OptionType implements Comparable<OptionType> {
   final int optionNumber;
 
   /// The name of this option.
-  final String name;
+  final String optionName;
 
   /// The [OptionFormat] of this option (integer, string, opaque, or unknown).
   final OptionFormat optionFormat;
-  const OptionType(this.optionNumber, this.name, this.optionFormat);
+  const OptionType(this.optionNumber, this.optionName, this.optionFormat);
 
   /// Creates a new [OptionType] object from a numeric [type].
   static OptionType fromTypeNumber(final int type) {

--- a/lib/src/stack/coap_chain.dart
+++ b/lib/src/stack/coap_chain.dart
@@ -163,7 +163,7 @@ class CoapEntry<TFilter, TNextFilter>
     if (prevEntry != null) {
       sb
         ..write('${prevEntry!.name}:')
-        ..write(prevEntry!.filter.getType().name);
+        ..write(prevEntry!.filter.getType().optionName);
     } else {
       sb.write('null');
     }
@@ -172,7 +172,7 @@ class CoapEntry<TFilter, TNextFilter>
     if (nextEntry != null) {
       sb
         ..write('${nextEntry!.name}:')
-        ..write(nextEntry!.filter.getType().name);
+        ..write(nextEntry!.filter.getType().optionName);
     } else {
       sb.write('null');
     }


### PR DESCRIPTION
In the current Dart version, using a `name` field in an enhanced enum (as we currently do in the `OptionType` enum) causes a segmentation fault (c.f., https://github.com/dart-lang/sdk/issues/49296). Although this will be fixed in the next version, this PR simply changes the identifier of the name in question as a workaround to avoid segfaults.