### PR TITLE
feat: expose `coap_defined_address.dart`

### DIFF
--- a/lib/coap.dart
+++ b/lib/coap.dart
@@ -21,6 +21,7 @@ export 'src/coap_client.dart';
 export 'src/coap_code.dart';
 export 'src/coap_config.dart';
 export 'src/coap_constants.dart';
+export 'src/coap_defined_address.dart';
 export 'src/coap_link_format.dart';
 export 'src/coap_media_type.dart';
 export 'src/coap_message_type.dart';


### PR DESCRIPTION
I noticed that the defined multicast addresses are another file that should be exported. This PR adjusts the top-level `coap.dart` file accordingly.