### PR TITLE
refactor!: use enhanced enum for ContentMediaType

### DIFF
--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -129,7 +129,7 @@ class CoapClient {
   /// Sends a GET request.
   Future<CoapResponse> get(
     final String path, {
-    final int accept = CoapMediaType.textPlain,
+    final CoapMediaType accept = CoapMediaType.textPlain,
     final int type = CoapMessageType.con,
     final List<CoapOption>? options,
     final bool earlyBlock2Negotiation = false,
@@ -153,8 +153,8 @@ class CoapClient {
   Future<CoapResponse> post(
     final String path, {
     required final String payload,
-    final int format = CoapMediaType.textPlain,
-    final int accept = CoapMediaType.textPlain,
+    final CoapMediaType format = CoapMediaType.textPlain,
+    final CoapMediaType accept = CoapMediaType.textPlain,
     final int type = CoapMessageType.con,
     final List<CoapOption>? options,
     final bool earlyBlock2Negotiation = false,
@@ -178,8 +178,8 @@ class CoapClient {
   Future<CoapResponse> postBytes(
     final String path, {
     required final Uint8Buffer payload,
-    final int format = CoapMediaType.textPlain,
-    final int accept = CoapMediaType.textPlain,
+    final CoapMediaType format = CoapMediaType.textPlain,
+    final CoapMediaType accept = CoapMediaType.textPlain,
     final int type = CoapMessageType.con,
     final List<CoapOption>? options,
     final bool earlyBlock2Negotiation = false,
@@ -203,8 +203,8 @@ class CoapClient {
   Future<CoapResponse> put(
     final String path, {
     required final String payload,
-    final int format = CoapMediaType.textPlain,
-    final int accept = CoapMediaType.textPlain,
+    final CoapMediaType format = CoapMediaType.textPlain,
+    final CoapMediaType accept = CoapMediaType.textPlain,
     final int type = CoapMessageType.con,
     final List<Uint8Buffer>? etags,
     final MatchEtags matchEtags = MatchEtags.onMatch,
@@ -232,10 +232,10 @@ class CoapClient {
   Future<CoapResponse> putBytes(
     final String path, {
     required final Uint8Buffer payload,
-    final int format = CoapMediaType.textPlain,
+    final CoapMediaType format = CoapMediaType.textPlain,
     final MatchEtags matchEtags = MatchEtags.onMatch,
     final List<Uint8Buffer>? etags,
-    final int accept = CoapMediaType.textPlain,
+    final CoapMediaType accept = CoapMediaType.textPlain,
     final int type = CoapMessageType.con,
     final List<CoapOption>? options,
     final bool earlyBlock2Negotiation = false,
@@ -260,7 +260,7 @@ class CoapClient {
   /// Sends a DELETE request
   Future<CoapResponse> delete(
     final String path, {
-    final int accept = CoapMediaType.textPlain,
+    final CoapMediaType accept = CoapMediaType.textPlain,
     final int type = CoapMessageType.con,
     final List<CoapOption>? options,
     final bool earlyBlock2Negotiation = false,
@@ -375,7 +375,7 @@ class CoapClient {
   void _build(
     final CoapRequest request,
     final String path,
-    final int accept,
+    final CoapMediaType accept,
     final int type,
     final List<CoapOption>? options,
     final bool earlyBlock2Negotiation,
@@ -413,12 +413,9 @@ class CoapClient {
     request
       ..uri = uri
       ..timestamp = DateTime.now()
-      ..eventBus = _eventBus;
-
-    // Set a default accept
-    if (request.accept == CoapMediaType.undefined) {
-      request.accept = CoapMediaType.textPlain;
-    }
+      ..eventBus = _eventBus
+      // Set a default accept
+      ..accept ??= CoapMediaType.textPlain;
 
     await _lock.synchronized(() async {
       // Set endpoint if missing

--- a/lib/src/coap_media_type.dart
+++ b/lib/src/coap_media_type.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: avoid_classes_with_only_static_members
-
 /*
  * Package : Coap
  * Author : S. Hamblett <steve.hamblett@linux.com>
@@ -7,288 +5,309 @@
  * Copyright :  S.Hamblett
  */
 
+import 'dart:io';
 import 'package:collection/collection.dart';
 
-import 'coap_option.dart';
-
-/// This class describes the CoAP Media Type Registry as defined in
+/// This enum describes the CoAP Media Type Registry as defined in
 /// RFC 7252, Section 12.3.
-class CoapMediaType {
-  /// Media registry
-  static final Map<int, List<String>> _registry = <int, List<String>>{
-    textPlain: <String>['text/plain', 'txt'],
-    imageGif: <String>['image/gif', 'gif'],
-    imageJpeg: <String>['image/jpeg', 'jpg'],
-    imagePng: <String>['image/png', 'png'],
-    applicationLinkFormat: <String>['application/link-format', 'wlnk'],
-    applicationXml: <String>['application/xml', 'xml'],
-    applicationOctetStream: <String>['application/octet-stream', 'bin'],
-    applicationExi: <String>['application/exi', 'exi'],
-    applicationJson: <String>['application/json', 'json'],
-    // FIXME: How to deal with undefined file extensions?
-    applicationJsonPatchJson: <String>['application/json-patch+json'],
-    applicationMergePatchJson: <String>['application/merge-patch+json'],
-    applicationCbor: <String>['application/cbor', 'cbor'],
-    applicationCwt: <String>['application/cwt'],
-    applicationMultipartCore: <String>['application/multipart-core'],
-    applicationCborSeq: <String>['application/cbor-seq'],
-    // FIXME: Add application/cose Content Formats
-    applicationCoseKey: <String>['application/cose-key', 'cbor'],
-    applicationCoseKeySet: <String>['application/cose-key-set', 'cbor'],
-    applicationSenmlJson: <String>['application/senml+json', 'senml'],
-    applicationSensmlJson: <String>['application/sensml+json', 'sensml'],
-    applicationSenmlCbor: <String>['application/senml+cbor', 'senmlc'],
-    applicationSensmlCbor: <String>['application/sensml+cbor', 'sensmlc'],
-    applicationSenmlExi: <String>['application/senml-exi', 'senmle'],
-    applicationSensmlExi: <String>['application/sensml-exi', 'sensmle'],
-    applicationCoapGroupJson: <String>['application/coap-group+json', 'json'],
-    applicationDotsCbor: <String>['application/dots+cbor'],
-    applicationMissingBlocksCborSeq: <String>[
-      'application/missing-blocks+cbor-seq'
-    ],
-    // FIXME: Add application/pkcs7-mime Content Formats
-    applicationPkcs8: <String>['application/pkcs8'],
-    applicationCsrattrs: <String>['application/csrattrs'],
-    applicationPkcs10: <String>['application/pkcs10'],
-    applicationPkixCert: <String>['application/pkix-cert'],
-    applicationSenmlXml: <String>['application/senml+xml', 'senmlx'],
-    applicationSensmlXml: <String>['application/sensml+xml', 'sensmlx'],
-    applicationSenmlEtchJson: <String>[
-      'application/senml-etch+json',
-      'senml-etchj'
-    ],
-    applicationSenmlEtchCbor: <String>[
-      'application/senml-etch+cbor',
-      'senml-etchc'
-    ],
-    applicationTdJson: <String>['application/td+json', 'jsontd'],
-    applicationVndOcfCbor: <String>['application/vnd.ocf+cbor'],
-    applicationOscore: <String>['application/oscore'],
-    applicationJavascript: <String>['application/javascript', 'js'],
-    textCss: <String>['text/css', 'css'],
-  };
-
-  /// undefined
-  static const int undefined = -1;
-
+enum CoapMediaType {
   /// text/plain; charset=utf-8
-  static const int textPlain = 0;
+  textPlain(0, 'text', 'plain', charset: 'utf-8'),
+
+  /// application/cose; cose-type="cose-encrypt0"
+  applicationCoseCoseTypeCoseEncrypt0(
+    16,
+    'application',
+    'cose',
+    parameters: {'cose-type': 'cose-encrypt0'},
+  ),
+
+  /// application/cose; cose-type="cose-mac0"
+  applicationCoseCoseTypeCoseMac0(
+    17,
+    'application',
+    'cose',
+    parameters: {'cose-type': 'cose-mac0'},
+  ),
+
+  /// application/cose; cose-type="cose-sign1"
+  applicationCoseCoseTypeCoseSign1(
+    18,
+    'application',
+    'cose',
+    parameters: {'cose-type': 'cose-sign1'},
+  ),
 
   /// image/gif
-  static const int imageGif = 21;
+  imageGif(21, 'image', 'gif'),
 
   /// image/jpeg
-  static const int imageJpeg = 22;
+  imageJpeg(22, 'image', 'jpeg'),
 
   /// image/png
-  static const int imagePng = 23;
+  imagePng(23, 'image', 'png'),
 
   /// application/link-format
-  static const int applicationLinkFormat = 40;
+  applicationLinkFormat(
+    40,
+    'application',
+    'link-format',
+  ),
 
   /// application/xml
-  static const int applicationXml = 41;
+  applicationXml(41, 'application', 'xml'),
 
   /// application/octet-stream
-  static const int applicationOctetStream = 42;
+  applicationOctetStream(
+    42,
+    'application',
+    'octet-stream',
+  ),
 
   /// application/exi
-  static const int applicationExi = 47;
+  applicationExi(47, 'application', 'exi'),
 
   /// application/json
-  static const int applicationJson = 50;
+  applicationJson(50, 'application', 'json'),
 
   /// application/json-patch+json
-  static const int applicationJsonPatchJson = 51;
+  applicationJsonPatchJson(51, 'application', 'json-patch+json'),
 
   /// application/merge-patch+json
-  static const int applicationMergePatchJson = 52;
+  applicationMergePatchJson(52, 'application', 'merge-patch+json'),
 
   /// application/cbor
-  static const int applicationCbor = 60;
+  applicationCbor(60, 'application', 'cbor'),
 
   /// application/cwt
-  static const int applicationCwt = 61;
+  applicationCwt(61, 'application', 'cwt'),
 
   /// application/multipart-core
-  static const int applicationMultipartCore = 62;
+  applicationMultipartCore(62, 'application', 'multipart-core'),
 
   /// application/cbor-seq
-  static const int applicationCborSeq = 63;
+  applicationCborSeq(63, 'application', 'cbor-seq'),
+
+  /// application/cose; cose-type="cose-encrypt"
+  applicationCoseCoseTypeCoseEncrypt(
+    96,
+    'application',
+    'cose',
+    parameters: {'cose-type': 'cose-encrypt'},
+  ),
+
+  /// application/cose; cose-type="cose-mac"
+  applicationCoseCoseTypeCoseMac(
+    97,
+    'application',
+    'cose',
+    parameters: {'cose-type': 'cose-mac'},
+  ),
+
+  /// application/cose; cose-type="cose-sign"
+  applicationCoseCoseTypeCoseSign(
+    98,
+    'application',
+    'cose',
+    parameters: {'cose-type': 'cose-sign'},
+  ),
 
   /// application/cose-key
-  static const int applicationCoseKey = 101;
+  applicationCoseKey(101, 'application', 'cose-key'),
 
   /// application/cose-key-set
-  static const int applicationCoseKeySet = 102;
+  applicationCoseKeySet(102, 'application', 'cose-key-set'),
 
   /// application/senml+json
-  static const int applicationSenmlJson = 110;
+  applicationSenmlJson(110, 'application', 'senml+json'),
 
   /// application/sensml+json
-  static const int applicationSensmlJson = 111;
-
-  /// application/senml+cbor
-  static const int applicationSenmlCbor = 112;
+  applicationSensmlJson(111, 'application', 'sensml+json'),
 
   /// application/sensml+cbor
-  static const int applicationSensmlCbor = 113;
+  applicationSensmlCbor(113, 'application', 'sensml+cbor'),
 
   /// application/senml-exi
-  static const int applicationSenmlExi = 114;
+  applicationSenmlExi(114, 'application', 'senml-exi'),
 
   /// application/sensml-exi
-  static const int applicationSensmlExi = 115;
+  applicationSensmlExi(115, 'application', 'sensml-exi'),
+
+  /// application/yang-data+cbor; id=sid
+  applicationYangDataCborSid(
+    140,
+    'application',
+    'sensml-exi',
+    parameters: {'id': 'sid'},
+  ),
 
   /// application/coap-group+json
-  static const int applicationCoapGroupJson = 256;
+  applicationCoapGroupJson(256, 'application', 'coap-group+json'),
 
   /// application/dots+cbor
-  static const int applicationDotsCbor = 271;
+  applicationDotsCbor(271, 'application', 'dots+cbor'),
 
   /// application/missing-blocks+cbor-seq
-  static const int applicationMissingBlocksCborSeq = 272;
+  applicationMissingBlocksCborSeq(
+    272,
+    'application',
+    'missing-blocks+cbor-seq',
+  ),
+
+  /// application/pkcs7-mime; smime-type=server-generated-key
+  applicationPkcs7MimeServerGeneratedKey(
+    281,
+    'application',
+    'pkcs7-mime',
+    parameters: {'mime-type': 'server-generated-key'},
+  ),
+
+  /// application/pkcs7-mime; smime-type=certs-only
+  applicationPkcs7MimeCertsOnly(
+    281,
+    'application',
+    'pkcs7-mime',
+    parameters: {'mime-type': 'certs-only'},
+  ),
 
   /// application/pkcs8
-  static const int applicationPkcs8 = 284;
+  applicationPkcs8(284, 'application', 'pkcs8'),
 
   /// application/csrattrs
-  static const int applicationCsrattrs = 285;
+  applicationCsrattrs(285, 'application', 'csrattrs'),
 
   /// application/pkcs10
-  static const int applicationPkcs10 = 286;
+  applicationPkcs10(286, 'application', 'pkcs10'),
 
   /// application/pkix-cert
-  static const int applicationPkixCert = 287;
+  applicationPkixCert(287, 'application', 'pkix-cert'),
+
+  /// application/aif+cbor
+  applicationAifCbor(290, 'application', 'aif+cbor'),
+
+  /// application/aif+json
+  applicationAifJson(291, 'application', 'aif+json'),
 
   /// application/senml+xml
-  static const int applicationSenmlXml = 310;
+  applicationSenmlXml(310, 'application', 'senml+xml'),
 
   /// application/sensml+xml
-  static const int applicationSensmlXml = 311;
+  applicationSensmlXml(311, 'application', 'sensml+xml'),
 
   /// application/senml-etch+json
-  static const int applicationSenmlEtchJson = 320;
+  applicationSenmlEtchJson(320, 'application', 'senml-etch+json'),
 
   /// application/senml-etch+cbor
-  static const int applicationSenmlEtchCbor = 322;
+  applicationSenmlEtchCbor(322, 'application', 'senml-etch+cbor'),
+
+  /// application/yang-data+cbor
+  applicationYangCbor(340, 'application', 'yang-data+cbor'),
+
+  /// application/yang-data+cbor
+  applicationSenmlEtchCborIdName(
+    341,
+    'application',
+    'senml-etch+cbor',
+    parameters: {'id': 'name'},
+  ),
 
   /// application/td+json
-  static const int applicationTdJson = 432;
+  applicationTdJson(432, 'application', 'application/td+json'),
 
   /// application/vnd.ocf+cbor
-  static const int applicationVndOcfCbor = 10000;
+  applicationVndOcfCbor(10000, 'application', 'vnd.ocf+cbor'),
 
   /// application/oscore
-  static const int applicationOscore = 10001;
+  applicationOscore(10001, 'application', 'oscore'),
 
   /// application/javascript
-  static const int applicationJavascript = 10002;
+  applicationJavascript(10002, 'application', 'javascript'),
 
-  /// text/css
-  static const int textCss = 20000;
+  /// application/json@deflate
+  applictionJsonDeflate(11050, 'application', 'json', encoding: 'deflate'),
 
-  /// image/svg+xml
-  static const int imageSvgXml = 30000;
+  /// application/cbor@deflate
+  applictionCborDeflate(11060, 'application', 'cbor', encoding: 'deflate'),
 
-  /// any
-  static const int any = 0xFF;
+  /// application/textCss
+  textCss(20000, 'text', 'css'),
+
+  /// application/svg+xml
+  imageSvgXml(30000, 'image', 'svg+xml'),
+  ;
+
+  const CoapMediaType(
+    this.numericValue,
+    this.primaryType,
+    this.subType, {
+    this.charset,
+    this.parameters = const {},
+    this.encoding,
+  });
+
+  final int numericValue;
+
+  String get mimeType => '$primaryType/$subType';
+
+  final String primaryType;
+
+  final String subType;
+
+  final String? charset;
+
+  final Map<String, String?> parameters;
+
+  final String? encoding;
+
+  ContentType get contentType => ContentType(
+        primaryType,
+        subType,
+        charset: charset,
+        parameters: parameters,
+      );
+
+  // TODO(JKRhb): Rework to switch statement?
+  static CoapMediaType? fromIntValue(final int value) => CoapMediaType.values
+      .firstWhereOrNull((final element) => element.numericValue == value);
+
+  /// Parses a string-based contentType [value] and [encoding] and returns
+  /// a [CoapMediaType], if a match has been found.
+  ///
+  /// Otherwise, it returns `null`.
+  static CoapMediaType? parse(final String value, [final String? encoding]) {
+    final contentType = ContentType.parse(value);
+
+    return CoapMediaType.values.firstWhereOrNull(
+      (final element) =>
+          element.contentType.toString() == contentType.toString() &&
+          element.encoding == encoding,
+    );
+  }
+
+  /// Indicates if this [CoapMediaType] is printable.
+  // TODO(JKRhb): Are there any uncovered cases?
+  bool get isPrintable =>
+      primaryType == 'text' ||
+      subType.endsWith('xml') ||
+      subType.endsWith('json') ||
+      this == applicationLinkFormat ||
+      this == applicationJavascript;
 
   /// Checks whether the given media type is a type of image.
   /// True iff the media type is a type of image.
-  static bool isImage(final int mediaType) =>
-      mediaType >= imageGif && mediaType <= imagePng;
+  bool get isImage => primaryType == 'image';
 
-  /// Is the media type printable
-  static bool isPrintable(final int? mediaType) {
-    switch (mediaType) {
-      case textPlain:
-      case applicationLinkFormat:
-      case applicationJavascript:
-      case textCss:
-
-      // XML based mediaTypes
-      case applicationXml:
-      case applicationSenmlXml:
-      case applicationSensmlXml:
-      case imageSvgXml:
-
-      // JSON based mediaTypes
-      case applicationJson:
-      case applicationJsonPatchJson:
-      case applicationMergePatchJson:
-      case applicationSenmlJson:
-      case applicationSensmlJson:
-      case applicationCoapGroupJson:
-      case applicationSenmlEtchJson:
-      case applicationTdJson:
-
-      case undefined:
-        return true;
-      default:
-        return false;
-    }
-  }
-
-  /// Returns a string representation of the media type.
+  /// Formats the Content Encoding as described in [RFC 9193, section 3].
   ///
-  /// Returns 'application/octet-stream' as the default if the [mediaType] code
-  /// is unknown.
-  static String name(final int mediaType) {
-    if (_registry.containsKey(mediaType)) {
-      return _registry[mediaType]![0];
-    } else {
-      return 'application/octet-stream';
+  /// [RFC 9193, section 3]:  https://datatracker.ietf.org/doc/html/rfc9193#section-3
+  String get _formattedEncoding {
+    if (encoding == null) {
+      return '';
     }
+
+    return '@$encoding';
   }
 
-  /// Gets the file extension of the given media type.
-  ///
-  /// Returns 'undefined' if the [mediaType] cannot be resolved.
-  static String fileExtension(final int mediaType) {
-    if (_registry.containsKey(mediaType) && _registry[mediaType]!.length > 1) {
-      return _registry[mediaType]![1];
-    }
-
-    return 'undefined';
-  }
-
-  /// Negotiation content
-  static int negotiationContent(
-    final int defaultContentType,
-    final List<int> supported,
-    final List<CoapOption>? accepted,
-  ) {
-    if (accepted == null) {
-      return defaultContentType;
-    }
-    var hasAccept = false;
-    for (final opt in accepted) {
-      for (final ct in supported) {
-        if (ct == opt.intValue) {
-          return ct;
-        }
-      }
-      hasAccept = true;
-    }
-    return hasAccept ? CoapMediaType.undefined : defaultContentType;
-  }
-
-  /// Parse
-  static int? parse(final String type) =>
-      _registry.keys.firstWhereOrNull(
-        (final key) => _registry[key]![0].toLowerCase() == type.toLowerCase(),
-      ) ??
-      CoapMediaType.undefined;
-
-  /// Wildcard parse
-  static List<int>? parseWildcard(final String? regex) {
-    if (regex == null) {
-      return null;
-    }
-    final r = RegExp('${regex.substring(0, regex.indexOf('*')).trim()}.*');
-    return _registry.keys
-        .where((final key) => r.hasMatch(_registry[key]![0]))
-        .toList();
-  }
+  @override
+  String toString() => contentType.toString() + _formattedEncoding;
 }

--- a/lib/src/coap_message.dart
+++ b/lib/src/coap_message.dart
@@ -333,7 +333,7 @@ class CoapMessage {
   }
 
   /// Sets the payload and media type of this CoAP message.
-  void setPayloadMedia(final String? payload, final int mediaType) {
+  void setPayloadMedia(final String? payload, final CoapMediaType mediaType) {
     if (payload == null) {
       return;
     }
@@ -343,7 +343,10 @@ class CoapMessage {
   }
 
   /// Sets the payload of this CoAP message.
-  void setPayloadMediaRaw(final Uint8Buffer payload, final int mediaType) {
+  void setPayloadMediaRaw(
+    final Uint8Buffer payload,
+    final CoapMediaType mediaType,
+  ) {
     this.payload = payload;
     contentType = mediaType;
   }
@@ -768,24 +771,30 @@ class CoapMessage {
   }
 
   /// Content type
-  int get contentType {
+  CoapMediaType? get contentType {
     final opt = getFirstOption(OptionType.contentFormat);
-    return opt?.value as int? ?? CoapMediaType.undefined;
+    if (opt == null) {
+      return null;
+    }
+
+    return CoapMediaType.fromIntValue(opt.intValue);
   }
 
-  set contentType(final int value) {
-    if (value == CoapMediaType.undefined) {
+  set contentType(final CoapMediaType? value) {
+    if (value == null) {
       removeOptions(OptionType.contentFormat);
     } else {
-      setOption(CoapOption.createVal(OptionType.contentFormat, value));
+      setOption(
+        CoapOption.createVal(OptionType.contentFormat, value.numericValue),
+      );
     }
   }
 
   /// The content-format of this CoAP message,
   /// Same as ContentType, only another name.
-  int get contentFormat => contentType;
+  CoapMediaType? get contentFormat => contentType;
 
-  set contentFormat(final int value) => contentType = value;
+  set contentFormat(final CoapMediaType? value) => contentType = value;
 
   /// The max-age of this CoAP message.
   int get maxAge {
@@ -806,16 +815,20 @@ class CoapMessage {
   }
 
   /// Accept
-  int get accept {
+  CoapMediaType? get accept {
     final opt = getFirstOption(OptionType.accept);
-    return opt?.value as int? ?? CoapMediaType.undefined;
+    if (opt == null) {
+      return null;
+    }
+
+    return CoapMediaType.fromIntValue(opt.intValue);
   }
 
-  set accept(final int value) {
-    if (value == CoapMediaType.undefined) {
+  set accept(final CoapMediaType? value) {
+    if (value == null) {
       removeOptions(OptionType.accept);
     } else {
-      setOption(CoapOption.createVal(OptionType.accept, value));
+      setOption(CoapOption.createVal(OptionType.accept, value.numericValue));
     }
   }
 
@@ -966,11 +979,11 @@ class CoapMessage {
       ..write(_optionString('Uri Port', uriPort > 0 ? uriPort : null))
       ..write(_optionString('Location Paths', locationPaths))
       ..write(_optionString('Uri Paths', uriPathsString))
-      ..write(_optionString('Content-Type', CoapMediaType.name(contentType)))
+      ..write(_optionString('Content-Type', contentType.toString()))
       ..write(_optionString('Max Age', maxAge))
       ..write(_optionString('Uri Queries', uriQueries));
-    if (accept != CoapMediaType.undefined) {
-      sb.write(_optionString('Accept', CoapMediaType.name(accept)));
+    if (accept != null) {
+      sb.write(_optionString('Accept', accept.toString()));
     }
     sb
       ..write(_optionString('Location Queries', locationQueries))

--- a/lib/src/coap_option.dart
+++ b/lib/src/coap_option.dart
@@ -126,7 +126,7 @@ class CoapOption {
     switch (_type.optionFormat) {
       case OptionFormat.integer:
         return (_type == OptionType.accept || _type == OptionType.contentFormat)
-            ? CoapMediaType.name(intValue)
+            ? CoapMediaType.fromIntValue(intValue).toString()
             : intValue.toString();
       case OptionFormat.string:
         return stringValue;

--- a/lib/src/stack/coap_blockwise_status.dart
+++ b/lib/src/stack/coap_blockwise_status.dart
@@ -7,6 +7,8 @@
 
 import 'package:typed_data/typed_data.dart';
 
+import '../../coap.dart';
+
 /// Represents the status of a blockwise transfer of a request or a response.
 class CoapBlockwiseStatus {
   /// Instantiates a new blockwise status.
@@ -35,10 +37,10 @@ class CoapBlockwiseStatus {
   bool get isRandomAccess => randomAccess;
 
   /// The Content-Format must stay the same for the whole transfer.
-  final int _contentFormat;
+  final CoapMediaType? _contentFormat;
 
   /// Content format
-  int get contentFormat => _contentFormat;
+  CoapMediaType? get contentFormat => _contentFormat;
 
   /// Complete
   bool complete = false;

--- a/test/coap_base_class_test.dart
+++ b/test/coap_base_class_test.dart
@@ -11,61 +11,17 @@ void main() {
   group('Media types', () {
     test('Properties', () {
       const type = CoapMediaType.applicationJson;
-      expect(CoapMediaType.name(type), 'application/json');
-      expect(CoapMediaType.fileExtension(type), 'json');
-      expect(CoapMediaType.isPrintable(type), true);
-      expect(CoapMediaType.isImage(type), false);
+      expect(type.mimeType, 'application/json');
+      expect(type.isPrintable, true);
+      expect(type.isImage, false);
 
       const unknownType = 200;
-      expect(CoapMediaType.name(unknownType), 'application/octet-stream');
-      expect(CoapMediaType.fileExtension(unknownType), 'undefined');
-      expect(CoapMediaType.isPrintable(unknownType), false);
-      expect(CoapMediaType.isImage(unknownType), false);
-    });
-
-    test('Negotiation Content', () {
-      const defaultContentType = 10;
-      final supported = <int>[11, 5];
-      final accepted = <CoapOption>[];
-      final opt1 = CoapOption.createVal(OptionType.maxAge, 10);
-      final opt2 = CoapOption.createVal(OptionType.contentFormat, 5);
-      accepted
-        ..add(opt1)
-        ..add(opt2);
-      expect(
-        CoapMediaType.negotiationContent(
-          defaultContentType,
-          supported,
-          accepted,
-        ),
-        5,
-      );
-      opt2.intValue = 67;
-      expect(
-        CoapMediaType.negotiationContent(
-          defaultContentType,
-          supported,
-          accepted,
-        ),
-        CoapMediaType.undefined,
-      );
+      expect(CoapMediaType.fromIntValue(unknownType), null);
     });
 
     test('Parse', () {
       final res = CoapMediaType.parse('application/xml');
       expect(res, CoapMediaType.applicationXml);
-    });
-
-    test('Parse wild card', () {
-      var res = CoapMediaType.parseWildcard(null);
-      expect(res, isNull);
-
-      res = CoapMediaType.parseWildcard('xml*');
-      expect(res, <int>[
-        CoapMediaType.applicationXml,
-        CoapMediaType.applicationSenmlXml,
-        CoapMediaType.applicationSensmlXml,
-      ]);
     });
   });
 

--- a/test/coap_message_encode_decode_test.dart
+++ b/test/coap_message_encode_decode_test.dart
@@ -196,7 +196,7 @@ void main() {
         ..addOption(
           CoapOption.createVal(
             OptionType.contentFormat,
-            CoapMediaType.textPlain,
+            CoapMediaType.textPlain.numericValue,
           ),
         )
         ..addOption(CoapOption.createVal(OptionType.maxAge, 30));
@@ -219,7 +219,7 @@ void main() {
       );
       expect(
         convMsg.getFirstOption(OptionType.contentFormat)!.intValue,
-        CoapMediaType.textPlain,
+        CoapMediaType.textPlain.numericValue,
       );
       expect(convMsg.getFirstOption(OptionType.maxAge)!.value, 30);
       expect(
@@ -265,8 +265,8 @@ void main() {
         ..addIfMatchOpaque(
           typed.Uint8Buffer()..addAll(<int>[88, 12, 254, 157, 5]),
         )
-        ..contentType = 40
-        ..accept = 40;
+        ..contentType = CoapMediaType.fromIntValue(40)
+        ..accept = CoapMediaType.fromIntValue(40);
 
       final bytes = spec.encode(request)!;
       checkData(spec.name, bytes, testNo);


### PR DESCRIPTION
This reworks the Content-Format registry as an enhanced enum and adds the missing values from the IANA CoAP [Content-Formats registry](https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#content-formats), also supporting those with parameters and encoding values.

CC @JosefWN 