### PR TITLE
Close gaps in Content-Format registry

### DIFF
--- a/lib/src/coap_media_type.dart
+++ b/lib/src/coap_media_type.dart
@@ -39,6 +39,9 @@ enum CoapMediaType {
   ),
 
   /// image/gif
+  applicationAceCbor(19, 'application', 'ace+cbor'),
+
+  /// image/gif
   imageGif(21, 'image', 'gif'),
 
   /// image/jpeg
@@ -123,6 +126,9 @@ enum CoapMediaType {
 
   /// application/sensml+json
   applicationSensmlJson(111, 'application', 'sensml+json'),
+
+  /// application/senml+cbor
+  applicationSenmlCbor(112, 'application', 'senml+cbor'),
 
   /// application/sensml+cbor
   applicationSensmlCbor(113, 'application', 'sensml+cbor'),
@@ -213,6 +219,9 @@ enum CoapMediaType {
 
   /// application/td+json
   applicationTdJson(432, 'application', 'application/td+json'),
+
+  /// application/voucher-cose+cbor
+  applicationVoucerCoseCbor(836, 'application', 'voucher-cose+cbor'),
 
   /// application/vnd.ocf+cbor
   applicationVndOcfCbor(10000, 'application', 'vnd.ocf+cbor'),

--- a/lib/src/coap_media_type.dart
+++ b/lib/src/coap_media_type.dart
@@ -162,7 +162,7 @@ enum CoapMediaType {
 
   /// application/pkcs7-mime; smime-type=server-generated-key
   applicationPkcs7MimeServerGeneratedKey(
-    281,
+    280,
     'application',
     'pkcs7-mime',
     parameters: {'mime-type': 'server-generated-key'},


### PR DESCRIPTION
Using the new Content-Format implementation, I noticed that there are a few entries from the [IANA registry](https://www.iana.org/assignments/core-parameters/core-parameters.xhtml) missing. This PR closes the gap. I also noticed a small bug with regard to one numeric value that is also fixed.