### PR TITLE
Fixes issue #107

### DIFF
--- a/lib/src/coap_empty_message.dart
+++ b/lib/src/coap_empty_message.dart
@@ -18,27 +18,24 @@ class CoapEmptyMessage extends CoapMessage {
 
   /// Create a new acknowledgment for the specified message.
   /// Returns the acknowledgment.
-  CoapEmptyMessage.newACK(final CoapMessage message) {
-    type = CoapMessageType.ack;
-    id = message.id;
-    token = CoapConstants.emptyToken;
-    destination = message.source;
-  }
+  factory CoapEmptyMessage.newACK(final CoapMessage message) =>
+      CoapEmptyMessage(CoapMessageType.ack)
+        ..id = message.id
+        ..token = CoapConstants.emptyToken
+        ..destination = message.source;
 
   /// Create a new reset message for the specified message.
   /// Return the reset.
-  CoapEmptyMessage.newRST(final CoapMessage message) {
-    type = CoapMessageType.rst;
-    id = message.id;
-    token = CoapConstants.emptyToken;
-    destination = message.source;
-  }
+  factory CoapEmptyMessage.newRST(final CoapMessage message) =>
+      CoapEmptyMessage(CoapMessageType.rst)
+        ..id = message.id
+        ..token = CoapConstants.emptyToken
+        ..destination = message.source;
 
   /// Create a new empty message confirmable for the specified message.
   /// Return the empty
-  CoapEmptyMessage.newCon(final CoapMessage message) {
-    type = CoapMessageType.con;
-    token = CoapConstants.emptyToken;
-    destination = message.source;
-  }
+  factory CoapEmptyMessage.newCon(final CoapMessage message) =>
+      CoapEmptyMessage(CoapMessageType.con)
+        ..token = CoapConstants.emptyToken
+        ..destination = message.source;
 }

--- a/lib/src/coap_request.dart
+++ b/lib/src/coap_request.dart
@@ -98,22 +98,14 @@ class CoapRequest extends CoapMessage {
   String toString() => '\n<<< Request Message >>>${super.toString()}';
 
   /// Construct a GET request.
-  CoapRequest.newGet() {
-    code = CoapCode.methodGET;
-  }
+  factory CoapRequest.newGet() => CoapRequest(CoapCode.methodGET);
 
   /// Construct a POST request.
-  CoapRequest.newPost() {
-    code = CoapCode.methodPOST;
-  }
+  factory CoapRequest.newPost() => CoapRequest(CoapCode.methodPOST);
 
   /// Construct a PUT request.
-  CoapRequest.newPut() {
-    code = CoapCode.methodPUT;
-  }
+  factory CoapRequest.newPut() => CoapRequest(CoapCode.methodPUT);
 
   /// Construct a DELETE request.
-  CoapRequest.newDelete() {
-    code = CoapCode.methodDELETE;
-  }
+  factory CoapRequest.newDelete() => CoapRequest(CoapCode.methodDELETE);
 }

--- a/lib/src/coap_response.dart
+++ b/lib/src/coap_response.dart
@@ -58,11 +58,11 @@ class CoapResponse extends CoapMessage {
   /// endpoint of the request.
   /// The response has the same token as the request.
   /// Type and ID are usually set automatically by the ReliabilityLayer>.
-  CoapResponse.createResponse(
+  factory CoapResponse.createResponse(
     final CoapRequest request,
-    this._statusCode,
-  ) {
-    destination = request.source;
-    token = request.token;
-  }
+    final int statusCode,
+  ) =>
+      CoapResponse(statusCode)
+        ..destination = request.source
+        ..token = request.token;
 }


### PR DESCRIPTION
The named constructors were not setting `CoapCode.empty`, converted to factory constructors to re-use the main constructor.

EDIT: Also had to downgrade a couple of dependencies to get things to work with the latest version of Flutter, a bit of an annoyance that they are not up to speed.