### PR TITLE
refactor!: rework `CoapCode` and `CoapMessageType` as enhanced enums

### DIFF
--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -16,6 +16,7 @@ import 'coap_block_option.dart';
 import 'coap_code.dart';
 import 'coap_config.dart';
 import 'coap_constants.dart';
+import 'coap_empty_message.dart';
 import 'coap_link_format.dart';
 import 'coap_media_type.dart';
 import 'coap_message.dart';
@@ -130,18 +131,17 @@ class CoapClient {
   Future<CoapResponse> get(
     final String path, {
     final CoapMediaType accept = CoapMediaType.textPlain,
-    final int type = CoapMessageType.con,
+    final bool confirmable = true,
     final List<CoapOption>? options,
     final bool earlyBlock2Negotiation = false,
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request = CoapRequest.newGet();
+    final request = CoapRequest.newGet(confirmable: confirmable);
     _build(
       request,
       path,
       accept,
-      type,
       options,
       earlyBlock2Negotiation,
       maxRetransmit,
@@ -155,18 +155,18 @@ class CoapClient {
     required final String payload,
     final CoapMediaType format = CoapMediaType.textPlain,
     final CoapMediaType accept = CoapMediaType.textPlain,
-    final int type = CoapMessageType.con,
+    final bool confirmable = true,
     final List<CoapOption>? options,
     final bool earlyBlock2Negotiation = false,
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request = CoapRequest.newPost()..setPayloadMedia(payload, format);
+    final request = CoapRequest.newPost(confirmable: confirmable)
+      ..setPayloadMedia(payload, format);
     _build(
       request,
       path,
       accept,
-      type,
       options,
       earlyBlock2Negotiation,
       maxRetransmit,
@@ -180,18 +180,18 @@ class CoapClient {
     required final Uint8Buffer payload,
     final CoapMediaType format = CoapMediaType.textPlain,
     final CoapMediaType accept = CoapMediaType.textPlain,
-    final int type = CoapMessageType.con,
+    final bool confirmable = true,
     final List<CoapOption>? options,
     final bool earlyBlock2Negotiation = false,
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request = CoapRequest.newPost()..setPayloadMediaRaw(payload, format);
+    final request = CoapRequest.newPost(confirmable: confirmable)
+      ..setPayloadMediaRaw(payload, format);
     _build(
       request,
       path,
       accept,
-      type,
       options,
       earlyBlock2Negotiation,
       maxRetransmit,
@@ -205,7 +205,7 @@ class CoapClient {
     required final String payload,
     final CoapMediaType format = CoapMediaType.textPlain,
     final CoapMediaType accept = CoapMediaType.textPlain,
-    final int type = CoapMessageType.con,
+    final bool confirmable = true,
     final List<Uint8Buffer>? etags,
     final MatchEtags matchEtags = MatchEtags.onMatch,
     final List<CoapOption>? options,
@@ -213,12 +213,12 @@ class CoapClient {
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request = CoapRequest.newPut()..setPayloadMedia(payload, format);
+    final request = CoapRequest.newPut(confirmable: confirmable)
+      ..setPayloadMedia(payload, format);
     _build(
       request,
       path,
       accept,
-      type,
       options,
       earlyBlock2Negotiation,
       maxRetransmit,
@@ -236,18 +236,18 @@ class CoapClient {
     final MatchEtags matchEtags = MatchEtags.onMatch,
     final List<Uint8Buffer>? etags,
     final CoapMediaType accept = CoapMediaType.textPlain,
-    final int type = CoapMessageType.con,
+    final bool confirmable = true,
     final List<CoapOption>? options,
     final bool earlyBlock2Negotiation = false,
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request = CoapRequest.newPut()..setPayloadMediaRaw(payload, format);
+    final request = CoapRequest.newPut(confirmable: confirmable)
+      ..setPayloadMediaRaw(payload, format);
     _build(
       request,
       path,
       accept,
-      type,
       options,
       earlyBlock2Negotiation,
       maxRetransmit,
@@ -261,18 +261,17 @@ class CoapClient {
   Future<CoapResponse> delete(
     final String path, {
     final CoapMediaType accept = CoapMediaType.textPlain,
-    final int type = CoapMessageType.con,
+    final bool confirmable = true,
     final List<CoapOption>? options,
     final bool earlyBlock2Negotiation = false,
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request = CoapRequest.newDelete();
+    final request = CoapRequest.newDelete(confirmable: confirmable);
     _build(
       request,
       path,
       accept,
-      type,
       options,
       earlyBlock2Negotiation,
       maxRetransmit,
@@ -365,10 +364,10 @@ class CoapClient {
   /// Cancels a request
   void cancel(final CoapRequest request) {
     request.isCancelled = true;
-    final response = CoapResponse(CoapCode.empty)
+    final response = CoapEmptyMessage(CoapMessageType.rst)
       ..id = request.id
       ..token = request.token;
-    _eventBus.fire(CoapRespondEvent(response));
+    _eventBus.fire(CoapCancelledEvent(response));
   }
 
   /// Cancel all ongoing requests
@@ -380,7 +379,6 @@ class CoapClient {
     final CoapRequest request,
     final String path,
     final CoapMediaType accept,
-    final int type,
     final List<CoapOption>? options,
     final bool earlyBlock2Negotiation,
     final int maxRetransmit, {
@@ -390,7 +388,6 @@ class CoapClient {
     request
       ..uriPath = path
       ..accept = accept
-      ..type = type
       ..maxRetransmit = maxRetransmit;
     if (options != null) {
       request.addOptions(options);

--- a/lib/src/coap_code.dart
+++ b/lib/src/coap_code.dart
@@ -35,6 +35,21 @@ enum CoapCode {
   /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
   delete(0, 04, 'DELETE'),
 
+  /// The FETCH method
+  ///
+  /// Defined in [RFC 8132](https://datatracker.ietf.org/doc/html/rfc8132).
+  fetch(0, 05, 'FETCH'),
+
+  /// The PATCH method
+  ///
+  /// Defined in [RFC 8132](https://datatracker.ietf.org/doc/html/rfc8132).
+  patch(0, 06, 'PATCH'),
+
+  /// The iPATCH method
+  ///
+  /// Defined in [RFC 8132](https://datatracker.ietf.org/doc/html/rfc8132).
+  ipatch(0, 07, 'iPATCH'),
+
   /// 2.01 Created
   ///
   /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).

--- a/lib/src/coap_code.dart
+++ b/lib/src/coap_code.dart
@@ -109,6 +109,11 @@ enum CoapCode {
     'Request Entity Incomplete',
   ),
 
+  /// 4.09 Conflict
+  ///
+  /// Defined in [RFC 8132](https://datatracker.ietf.org/doc/html/rfc8132).
+  conflict(4, 09, 'Conflict'),
+
   /// 4.12 Precondition Failed
   ///
   /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
@@ -128,6 +133,16 @@ enum CoapCode {
   ///
   /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
   unsupportedMediaType(4, 15, 'Unsupported Content-Format'),
+
+  /// 4.22 Unprocessable Entity
+  ///
+  /// Defined in [RFC 8132](https://datatracker.ietf.org/doc/html/rfc8132).
+  unprocessableEntity(4, 22, 'Unprocessable Entity'),
+
+  /// 4.29 Too Many Requests
+  ///
+  /// Defined in [RFC 8516](https://datatracker.ietf.org/doc/html/rfc8516).
+  tooManyRequests(4, 29, 'Too Many Requests'),
 
   /// 5.00 Internal Server Error
   ///
@@ -158,6 +173,11 @@ enum CoapCode {
   ///
   /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
   proxyingNotSupported(5, 05, 'Proxying Not Supported'),
+
+  /// 5.08 Hop Limit Reached
+  ///
+  /// Defined in [RFC 8768](https://datatracker.ietf.org/doc/html/rfc8768).
+  hopLimitReached(5, 08, 'Hop Limit Reached');
 
   const CoapCode(
     this.codeClass,

--- a/lib/src/coap_code.dart
+++ b/lib/src/coap_code.dart
@@ -192,7 +192,32 @@ enum CoapCode {
   /// 5.08 Hop Limit Reached
   ///
   /// Defined in [RFC 8768](https://datatracker.ietf.org/doc/html/rfc8768).
-  hopLimitReached(5, 08, 'Hop Limit Reached');
+  hopLimitReached(5, 08, 'Hop Limit Reached'),
+
+  /// 7.01 CSM
+  ///
+  /// Defined in [RFC 8323](https://datatracker.ietf.org/doc/html/rfc8323).
+  csm(7, 01, 'CSM'),
+
+  /// 7.02 Ping
+  ///
+  /// Defined in [RFC 8323](https://datatracker.ietf.org/doc/html/rfc8323).
+  ping(7, 02, 'Ping'),
+
+  /// 7.03 Pong
+  ///
+  /// Defined in [RFC 8323](https://datatracker.ietf.org/doc/html/rfc8323).
+  pong(7, 03, 'Pong'),
+
+  /// 7.04 Release
+  ///
+  /// Defined in [RFC 8323](https://datatracker.ietf.org/doc/html/rfc8323).
+  release(7, 04, 'Release'),
+
+  /// 7.05 Abort
+  ///
+  /// Defined in [RFC 8323](https://datatracker.ietf.org/doc/html/rfc8323).
+  abort(7, 05, 'Abort');
 
   const CoapCode(
     this.codeClass,
@@ -237,4 +262,7 @@ enum CoapCode {
 
   /// Checks whether this [CoapCode] represents a server error response code.
   bool get isServerError => codeClass == 5;
+
+  /// Checks whether this [CoapCode] indicates a signaling message.
+  bool get isSignaling => codeClass == 7;
 }

--- a/lib/src/coap_code.dart
+++ b/lib/src/coap_code.dart
@@ -7,290 +7,199 @@
  * Copyright :  S.Hamblett
  */
 
-/// This class describes the CoAP Code Registry as defined in  RFC 7252,
-/// section 12.1.
-class CoapCode {
-  /// Not set
-  static const int notSet = -1;
+import 'dart:collection';
 
-  /// Empty
-  static const int empty = 0;
-
-  /// Success
-  static const int successCode = 2;
-
-  /// Client error
-  static const int clientErrorCode = 4;
-
-  /// Server error
-  static const int serverErrorCode = 5;
-
-  /// Method Codes
+enum CoapCode {
+  /// Indicates an empty message
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
+  empty(0, 00, 'Empty'),
 
   /// The GET method
-  static const int get = 1;
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
+  get(0, 01, 'GET'),
 
   /// The POST method
-  static const int post = 2;
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
+  post(0, 02, 'POST'),
 
   /// The PUT method
-  static const int put = 3;
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
+  put(0, 03, 'PUT'),
 
   /// The DELETE method
-  static const int delete = 4;
-
-  /// Response Codes
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
+  delete(0, 04, 'DELETE'),
 
   /// 2.01 Created
-  static const int created = 65;
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
+  created(2, 01, 'Created'),
 
   /// 2.02 Deleted
-  static const int deleted = 66;
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
+  deleted(2, 02, 'Deleted'),
 
   /// 2.03 Valid
-  static const int valid = 67;
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
+  valid(2, 03, 'Valid'),
 
   /// 2.04 Changed
-  static const int changed = 68;
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
+  changed(2, 04, 'Changed'),
 
   /// 2.05 Content
-  static const int content = 69;
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
+  content(2, 05, 'Content'),
 
-  /// 2.?? Continue
-  static const int continues = 95;
+  /// 2.31 Continue
+  ///
+  /// Defined in [RFC 7959](https://datatracker.ietf.org/doc/html/rfc7959).
+  continues(2, 31, 'Continue'),
 
   /// 4.00 Bad Request
-  static const int badRequest = 128;
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
+  badRequest(4, 00, 'Bad Request'),
 
   /// 4.01 Unauthorized
-  static const int unauthorized = 129;
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
+  unauthorized(4, 01, 'Unauthorized'),
 
   /// 4.02 Bad Option
-  static const int badOption = 130;
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
+  badOption(4, 02, 'Bad Option'),
 
   /// 4.03 Forbidden
-  static const int forbidden = 131;
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
+  forbidden(4, 03, 'Forbidden'),
 
   /// 4.04 Not Found
-  static const int notFound = 132;
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
+  notFound(4, 04, 'Not Found'),
 
   /// 4.05 Method Not Allowed
-  static const int methodNotAllowed = 133;
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
+  methodNotAllowed(4, 05, 'Method Not Allowed'),
 
   /// 4.06 Not Acceptable
-  static const int notAcceptable = 134;
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
+  notAcceptable(4, 06, 'Not Acceptable'),
 
-  /// 4.08 Request Entity Incomplete (RFC 7959)
-  static const int requestEntityIncomplete = 136;
+  /// 4.08 Request Entity Incomplete
+  ///
+  /// Defined in [RFC 7959](https://datatracker.ietf.org/doc/html/rfc7959).
+  requestEntityIncomplete(
+    4,
+    08,
+    'Request Entity Incomplete',
+  ),
 
-  /// 4.12 Client not supported by server/headers don't satisfy protocol
-  static const int preconditionFailed = 140;
+  /// 4.12 Precondition Failed
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
+  preconditionFailed(4, 12, 'Precondition Failed'),
 
   /// 4.13 Request Entity Too Large
-  static const int requestEntityTooLarge = 141;
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252) and
+  /// [RFC 7959](https://datatracker.ietf.org/doc/html/rfc7959).
+  requestEntityTooLarge(
+    4,
+    13,
+    'Request Entity Too Large',
+  ),
 
-  /// 4.15 Unsupported Media Type
-  static const int unsupportedMediaType = 143;
+  /// 4.15 Unsupported Content-Format
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
+  unsupportedMediaType(4, 15, 'Unsupported Content-Format'),
 
   /// 5.00 Internal Server Error
-  static const int internalServerError = 160;
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
+  internalServerError(5, 00, 'Internal Server Error'),
 
   /// 5.01 Not Implemented
-  static const int notImplemented = 161;
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
+  notImplemented(5, 01, 'Not Implemented'),
 
   /// 5.02 Bad Gateway
-  static const int badGateway = 162;
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
+  badGateway(5, 02, 'Bad Gateway'),
 
   /// 5.03 Service Unavailable
-  static const int serviceUnavailable = 163;
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
+  serviceUnavailable(5, 03, 'Service Unavailable'),
 
   /// 5.04 Gateway Timeout
-  static const int gatewayTimeout = 164;
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
+  gatewayTimeout(5, 04, 'Gateway Timeout'),
 
   /// 5.05 Proxying Not Supported
-  static const int proxyingNotSupported = 165;
+  ///
+  /// Defined in [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252).
+  proxyingNotSupported(5, 05, 'Proxying Not Supported'),
 
-  /// Gets the response class
-  static int getResponseClass(final int code) => code >> 5 & 0x7;
+  const CoapCode(
+    this.codeClass,
+    this.codeDetail,
+    this.description,
+  ) : code = (codeClass << 5) + codeDetail;
 
-  /// Checks whether a code indicates a request
-  /// Returns true iff the code indicates a request
-  static bool isRequest(final int code) => (code >= 1) && (code <= 31);
+  static CoapCode? decode(final int code) => _codeRegistry[code];
 
-  /// Checks whether a code indicates a response
-  /// Returns true iff the code indicates a response
-  static bool isResponse(final int code) => (code >= 64) && (code <= 191);
+  static final _codeRegistry = HashMap.fromEntries(
+    values.map((final value) => MapEntry(value.code, value)),
+  );
 
-  /// Checks whether a code indicates an empty message
-  /// Returns true iff the code indicates an empty message
-  static bool isEmpty(final int code) => code == 0;
+  final int code;
 
-  /// Checks whether a code represents a success code.
-  static bool isSuccess(final int code) => code >= 64 && code < 96;
+  final int codeClass;
 
-  /// Checks whether a code is valid
-  /// Returns true iff the code is valid
-  static bool isValid(final int code) =>
-      (code >= 0) && (code <= 255); // allow unknown custom codes;
+  final int codeDetail;
 
-  /// Returns a string representation of the code
-  static String codeToString(final int code) {
-    switch (code) {
-      case notSet:
-        return 'Not Set';
-      case empty:
-        return 'Empty Message';
-      case get:
-        return 'GET';
-      case post:
-        return 'POST';
-      case put:
-        return 'PUT';
-      case delete:
-        return 'DELETE';
-      case created:
-        return '2.01 Created';
-      case deleted:
-        return '2.02 Deleted';
-      case valid:
-        return '2.03 Valid';
-      case changed:
-        return '2.04 Changed';
-      case content:
-        return '2.05 Content';
-      case badRequest:
-        return '4.00 Bad Request';
-      case unauthorized:
-        return '4.01 Unauthorized';
-      case badOption:
-        return '4.02 Bad Option';
-      case forbidden:
-        return '4.03 Forbidden';
-      case notFound:
-        return '4.04 Not Found';
-      case methodNotAllowed:
-        return '4.05 Method Not Allowed';
-      case notAcceptable:
-        return '4.06 Not Acceptable';
-      case requestEntityIncomplete:
-        return '4.08 Request Entity Incomplete';
-      case preconditionFailed:
-        return '4.12 Precondition Failed';
-      case requestEntityTooLarge:
-        return '4.13 Request Entity Too Large';
-      case unsupportedMediaType:
-        return '4.15 Unsupported Media Type';
-      case internalServerError:
-        return '5.00 Internal Server Error';
-      case notImplemented:
-        return '5.01 Not Implemented';
-      case badGateway:
-        return '5.02 Bad Gateway';
-      case serviceUnavailable:
-        return '5.03 Service Unavailable';
-      case gatewayTimeout:
-        return '5.04 Gateway Timeout';
-      case proxyingNotSupported:
-        return '5.05 Proxying Not Supported';
-      default:
-        break;
-    }
+  final String description;
 
-    if (isValid(code)) {
-      if (isRequest(code)) {
-        return 'Unknown Request [code {0}]';
-      } else if (isResponse(code)) {
-        return 'Unknown Response [code {0}]';
-      } else {
-        return 'Reserved [code {0}]';
-      }
-    } else {
-      return 'Invalid Message [code {0}]';
-    }
+  @override
+  String toString() {
+    final formattedDetail = codeDetail.toString().padLeft(2, '0');
+    return '$codeClass.$formattedDetail $description';
   }
 
-  /// Methods of request
+  /// Checks whether this [CoapCode] indicates an empty message.
+  bool get isEmpty => this == empty;
 
-  /// GET
-  static int methodGET = 1;
+  /// Checks whether this [CoapCode] indicates a request message.
+  bool get isRequest => codeClass == 0 && !isEmpty;
 
-  /// POST
-  static int methodPOST = 2;
+  /// Checks whether this [CoapCode] indicates a response message.
+  bool get isResponse => codeClass >= 2 && codeClass <= 5;
 
-  /// PUT
-  static int methodPUT = 3;
+  /// Checks whether this [CoapCode] represents a success response code.
+  bool get isSuccess => codeClass == 2;
 
-  /// DELETE
-  static int methodDELETE = 4;
+  /// Checks whether this [CoapCode] represents a client error response code.
+  bool get isErrorResponse => codeClass == 4;
 
-  /// Response status codes.
-
-  /// 2.01 Created
-  static const int statusCodeCreated = 65;
-
-  /// 2.02 Deleted
-  static const int statusCodeDeleted = 66;
-
-  /// 2.03 Valid
-  static const int statusCodeValid = 67;
-
-  /// 2.04 Changed
-  static const int statusCodeChanged = 68;
-
-  /// 2.05 Content
-  static const int statusCodeContent = 69;
-
-  /// 2.?? Continue
-  static const int statusCodeContinue = 95;
-
-  /// 4.00 Bad Request
-  static const int statusCodeBadRequest = 128;
-
-  /// 4.01 Unauthorized
-  static const int statusCodeUnauthorized = 129;
-
-  /// 4.02 Bad Option
-  static const int statusCodeBadOption = 130;
-
-  /// 4.03 Forbidden
-  static const int statusCodeForbidden = 131;
-
-  /// 4.04 Not Found
-  static const int statusCodeNotFound = 132;
-
-  /// 4.05 Method Not Allowed
-  static const int statusCodeMethodNotAllowed = 133;
-
-  /// 4.06 Not Acceptable
-  static const int statusCodeNotAcceptable = 134;
-
-  /// 4.08 Request Entity Incomplete (RFC 7959)
-  static const int statusCodeRequestEntityIncomplete = 136;
-
-  /// 4.12 Precondition failed
-  static const int statusCodePreconditionFailed = 140;
-
-  /// 4.13 Request Entity Too Large
-  static const int statusCodeRequestEntityTooLarge = 141;
-
-  /// 4.15 Unsupported Media Type
-  static const int statusCodeUnsupportedMediaType = 143;
-
-  /// 5.00 Internal Server Error
-  static const int statusCodeInternalServerError = 160;
-
-  /// 5.01 Not Implemented
-  static const int statusCodeNotImplemented = 161;
-
-  /// 5.02 Bad Gateway
-  static const int statusCodeBadGateway = 162;
-
-  /// 5.03 Service Unavailable
-  static const int statusCodeServiceUnavailable = 163;
-
-  /// 5.04 Gateway Timeout
-  static const int statusCodeGatewayTimeout = 164;
-
-  /// 5.05 Proxying Not Supported
-  static const int statusCodeProxyingNotSupported = 165;
+  /// Checks whether this [CoapCode] represents a server error response code.
+  bool get isServerError => codeClass == 5;
 }

--- a/lib/src/coap_empty_message.dart
+++ b/lib/src/coap_empty_message.dart
@@ -14,7 +14,7 @@ import 'coap_message_type.dart';
 /// the MessageType ACK or RST.
 class CoapEmptyMessage extends CoapMessage {
   /// Instantiates a new empty message.
-  CoapEmptyMessage(final int type) : super(type: type, code: CoapCode.empty);
+  CoapEmptyMessage(final CoapMessageType type) : super(CoapCode.empty, type);
 
   /// Create a new acknowledgment for the specified message.
   /// Returns the acknowledgment.

--- a/lib/src/coap_message.dart
+++ b/lib/src/coap_message.dart
@@ -30,26 +30,24 @@ typedef HookFunction = void Function();
 /// CoAP messages are of type Request, Response or EmptyMessage,
 /// each of which has a MessageType, a message identifier,
 /// a token (0-8 bytes), a collection of Options and a payload.
-class CoapMessage {
-  /// Constructor
-  CoapMessage({
-    this.type = CoapMessageType.unknown,
-    this.code = CoapCode.notSet,
-  });
-
-  /// Indicates that no ID has been set.
-  static const int none = -1;
+abstract class CoapMessage {
+  CoapMessage(this.code, this._type);
 
   bool hasUnknownCriticalOption = false;
 
+  CoapMessageType? _type;
+
+  @internal
+  set type(final CoapMessageType? type) => _type = type;
+
   /// The type of this CoAP message.
-  int type = CoapMessageType.unknown;
+  CoapMessageType? get type => _type;
 
   /// The code of this CoAP message.
-  int code = CoapCode.notSet;
+  final CoapCode code;
 
   /// The codestring
-  String get codeString => CoapCode.codeToString(code);
+  String get codeString => code.toString();
 
   int? _id;
 
@@ -166,19 +164,15 @@ class CoapMessage {
 
   /// Gets a value that indicates whether this CoAP message is a
   /// request message.
-  bool get isRequest => CoapCode.isRequest(code);
+  bool get isRequest => code.isRequest;
 
   /// Gets a value that indicates whether this CoAP message is a
   /// response message.
-  bool get isResponse => CoapCode.isResponse(code);
+  bool get isResponse => code.isResponse;
 
   /// Gets a value that indicates whether this CoAP message is
   /// an empty message.
-  bool get isEmpty => CoapCode.isEmpty(code);
-
-  /// Gets a value that indicates whether this CoAP message is a
-  /// valid message.
-  bool get isValid => CoapCode.isValid(code);
+  bool get isEmpty => code.isEmpty;
 
   /// The destination endpoint.
   @internal

--- a/lib/src/coap_message_type.dart
+++ b/lib/src/coap_message_type.dart
@@ -5,21 +5,38 @@
  * Copyright :  S.Hamblett
  */
 
-/// Types of CoAP messages.
-class CoapMessageType {
-  /// Unknown type.
-  static const int unknown = -1;
+import 'dart:collection';
 
+/// Types of CoAP messages.
+enum CoapMessageType {
   /// Confirmable messages require an acknowledgement.
-  static const int con = 0;
+  con(0, 'Confirmable'),
 
   /// Non-Confirmable messages do not require an acknowledgement.
-  static const int non = 1;
+  non(1, 'Non-Confirmable'),
 
   /// Acknowledgement messages acknowledge a specific confirmable message.
-  static const int ack = 2;
+  ack(2, 'Acknowledgement'),
 
   /// Reset messages indicate that a specific confirmable message was received,
   /// but some context is missing to properly process it.
-  static const int rst = 3;
+  rst(3, 'Reset');
+
+  const CoapMessageType(this.code, this.description);
+
+  final int code;
+
+  final String description;
+
+  static final _registry = HashMap.fromEntries(
+    values.map((final value) => MapEntry(value.code, value)),
+  );
+
+  static CoapMessageType? decode(final int code) => _registry[code];
+
+  static CoapMessageType requestType({required final bool confirmable}) =>
+      confirmable ? con : non;
+
+  @override
+  String toString() => 'Message type $code: $description';
 }

--- a/lib/src/coap_request.dart
+++ b/lib/src/coap_request.dart
@@ -23,17 +23,21 @@ import 'net/coap_iendpoint.dart';
 class CoapRequest extends CoapMessage {
   /// Initializes a request message.
   /// Defaults to confirmable
-  CoapRequest(final int code, {final bool confirmable = true})
+  CoapRequest(final CoapCode code, {final bool confirmable = true})
       : super(
-          code: code,
-          type: confirmable ? CoapMessageType.con : CoapMessageType.non,
-        );
+          code,
+          confirmable ? CoapMessageType.con : CoapMessageType.non,
+        ) {
+    if (!code.isRequest && !code.isEmpty) {
+      throw ArgumentError('Expected CoAP method code, got $code');
+    }
+  }
 
   /// The request method(code)
-  int get method => super.code;
+  CoapCode get method => code;
 
   @override
-  int get type {
+  CoapMessageType? get type {
     if (super.type == CoapMessageType.con && isMulticast) {
       return CoapMessageType.non;
     }
@@ -98,14 +102,20 @@ class CoapRequest extends CoapMessage {
   String toString() => '\n<<< Request Message >>>${super.toString()}';
 
   /// Construct a GET request.
-  factory CoapRequest.newGet() => CoapRequest(CoapCode.methodGET);
+  factory CoapRequest.newGet({final bool confirmable = true}) =>
+      CoapRequest(CoapCode.get, confirmable: confirmable);
 
   /// Construct a POST request.
-  factory CoapRequest.newPost() => CoapRequest(CoapCode.methodPOST);
+  factory CoapRequest.newPost({final bool confirmable = true}) =>
+      CoapRequest(CoapCode.post, confirmable: confirmable);
 
   /// Construct a PUT request.
-  factory CoapRequest.newPut() => CoapRequest(CoapCode.methodPUT);
+  factory CoapRequest.newPut({final bool confirmable = true}) =>
+      CoapRequest(CoapCode.put, confirmable: confirmable);
 
   /// Construct a DELETE request.
-  factory CoapRequest.newDelete() => CoapRequest(CoapCode.methodDELETE);
+  factory CoapRequest.newDelete({final bool confirmable = true}) =>
+      CoapRequest(CoapCode.delete, confirmable: confirmable);
+
+  // TODO(JKRhb): Add constructors for FETCH, PATCH, and iPATCH
 }

--- a/lib/src/coap_response.dart
+++ b/lib/src/coap_response.dart
@@ -10,6 +10,7 @@ import 'package:typed_data/typed_buffers.dart';
 
 import 'coap_code.dart';
 import 'coap_message.dart';
+import 'coap_message_type.dart';
 import 'coap_request.dart';
 
 /// Represents a CoAP response to a CoAP request.
@@ -17,15 +18,14 @@ import 'coap_request.dart';
 /// or a separate response with type CON or NON.
 class CoapResponse extends CoapMessage {
   /// Initializes a response message.
-  CoapResponse(this._statusCode) : super(code: _statusCode);
-
-  final int _statusCode;
-
-  /// The response status code.
-  int get statusCode => _statusCode;
+  CoapResponse(super.code, super.type) {
+    if (!code.isResponse) {
+      throw ArgumentError('Expected CoAP response code, got $code');
+    }
+  }
 
   /// Status code as a string
-  String get statusCodeString => CoapCode.codeToString(_statusCode);
+  String get statusCodeString => code.toString();
 
   Uint8Buffer? _multicastToken;
 
@@ -35,6 +35,8 @@ class CoapResponse extends CoapMessage {
   set multicastToken(final Uint8Buffer? val) => _multicastToken = val;
 
   Duration? _rtt;
+
+  bool get isSuccess => code.isSuccess;
 
   /// The Round-Trip Time of this response.
   Duration? get rtt => _rtt;
@@ -60,9 +62,10 @@ class CoapResponse extends CoapMessage {
   /// Type and ID are usually set automatically by the ReliabilityLayer>.
   factory CoapResponse.createResponse(
     final CoapRequest request,
-    final int statusCode,
+    final CoapCode statusCode,
+    final CoapMessageType type,
   ) =>
-      CoapResponse(statusCode)
+      CoapResponse(statusCode, type)
         ..destination = request.source
         ..token = request.token;
 }

--- a/lib/src/codec/decoders/coap_message_decoder_rfc7252.dart
+++ b/lib/src/codec/decoders/coap_message_decoder_rfc7252.dart
@@ -7,10 +7,8 @@
 
 import 'package:typed_data/typed_data.dart';
 
-import '../../coap_code.dart';
 import '../../coap_constants.dart';
 import '../../coap_message.dart';
-import '../../coap_message_type.dart';
 import '../../coap_option.dart';
 import '../../coap_option_type.dart';
 import '../../specification/rfcs/coap_rfc7252.dart';
@@ -48,15 +46,15 @@ class CoapMessageDecoder18 extends CoapMessageDecoder {
     _id = super.reader.read(CoapRfc7252.idBits);
   }
 
-  int _type = CoapMessageType.unknown;
+  int? _type;
 
   @override
-  int get type => _type;
+  int? get type => _type;
 
-  int _code = CoapCode.notSet;
+  int? _code;
 
   @override
-  int get code => _code;
+  int? get code => _code;
 
   @override
   void parseMessage(final CoapMessage message) {

--- a/lib/src/codec/encoders/coap_message_encoder.dart
+++ b/lib/src/codec/encoders/coap_message_encoder.dart
@@ -20,21 +20,21 @@ abstract class CoapMessageEncoder implements CoapIMessageEncoder {
   @override
   Uint8Buffer encodeRequest(final CoapRequest request) {
     final writer = CoapDatagramWriter();
-    serialize(writer, request, request.code);
+    serialize(writer, request, request.code.code);
     return writer.toByteArray();
   }
 
   @override
   Uint8Buffer encodeResponse(final CoapResponse response) {
     final writer = CoapDatagramWriter();
-    serialize(writer, response, response.code);
+    serialize(writer, response, response.code.code);
     return writer.toByteArray();
   }
 
   @override
   Uint8Buffer encodeEmpty(final CoapEmptyMessage message) {
     final writer = CoapDatagramWriter();
-    serialize(writer, message, CoapCode.empty);
+    serialize(writer, message, CoapCode.empty.code);
     return writer.toByteArray();
   }
 

--- a/lib/src/codec/encoders/coap_message_encoder_rfc7252.dart
+++ b/lib/src/codec/encoders/coap_message_encoder_rfc7252.dart
@@ -26,7 +26,7 @@ class CoapMessageEncoderRfc7252 extends CoapMessageEncoder {
     // Write fixed-size CoAP headers
     writer
       ..write(CoapRfc7252.version, CoapRfc7252.versionBits)
-      ..write(message.type, CoapRfc7252.typeBits)
+      ..write(message.type?.code, CoapRfc7252.typeBits)
       ..write(message.token?.length ?? 0, CoapRfc7252.tokenLengthBits)
       ..write(code, CoapRfc7252.codeBits)
       ..write(message.id, CoapRfc7252.idBits)

--- a/lib/src/net/coap_exchange.dart
+++ b/lib/src/net/coap_exchange.dart
@@ -150,6 +150,10 @@ class CoapExchange {
   void fireRespond(final CoapResponse resp) =>
       _eventBus.fire(CoapRespondEvent(resp));
 
+  /// Fire a [CoapCancelledEvent].
+  void fireCancel(final CoapEmptyMessage cancellationMessage) =>
+      _eventBus.fire(CoapCancelledEvent(cancellationMessage));
+
   /// Attributes
   T? get<T>(final Object key) => _attributes[key] as T?;
 

--- a/lib/src/stack/coap_observe_layer.dart
+++ b/lib/src/stack/coap_observe_layer.dart
@@ -7,10 +7,8 @@
 
 import 'dart:async';
 
-import '../coap_code.dart';
 import '../coap_config.dart';
 import '../coap_empty_message.dart';
-import '../coap_message.dart';
 import '../coap_message_type.dart';
 import '../coap_option_type.dart';
 import '../coap_request.dart';
@@ -89,18 +87,13 @@ class CoapObserveLayer extends CoapAbstractLayer {
       if (exchange.request!.isAcknowledged ||
           exchange.request!.type == CoapMessageType.non) {
         // Transmit errors as CON
-        if (!CoapCode.isSuccess(response.code)) {
+        if (!response.isSuccess) {
           response.type = CoapMessageType.con;
           relation.cancel();
         } else {
           // Make sure that every now and than a CON is mixed within
           if (relation.check()) {
             response.type = CoapMessageType.con;
-          } else {
-            // By default use NON, but do not override resource decision
-            if (response.type == CoapMessageType.unknown) {
-              response.type = CoapMessageType.non;
-            }
           }
         }
       }
@@ -215,7 +208,7 @@ class CoapObserveLayer extends CoapAbstractLayer {
           ..nextControlNotification = null;
         if (next != null) {
           // this is not a self replacement, hence a new ID
-          next.id = CoapMessage.none;
+          next.id = null;
           sendResponse(nextLayer, exchange, next);
         }
       }

--- a/test/coap_message_api_test.dart
+++ b/test/coap_message_api_test.dart
@@ -6,7 +6,7 @@
  */
 
 import 'package:coap/coap.dart';
-import 'package:coap/src/coap_message.dart';
+import 'package:coap/src/coap_empty_message.dart';
 import 'package:coap/src/event/coap_event_bus.dart';
 import 'package:test/test.dart';
 
@@ -17,9 +17,8 @@ void main() {
   final DefaultCoapConfig conf = CoapConfigDefault();
 
   test('Construction', () {
-    final message = CoapMessage();
-    expect(message.type, CoapMessageType.unknown);
-    expect(message.code, CoapCode.notSet);
+    final message = CoapEmptyMessage(CoapMessageType.con);
+    expect(message.type, CoapMessageType.con);
     expect(message.id, null);
     expect(message.resolveHost, 'localhost');
     expect(message.optionMap.isEmpty, isTrue);
@@ -45,7 +44,7 @@ void main() {
   });
 
   test('Options', () {
-    final message = CoapMessage();
+    final message = CoapRequest(CoapCode.get);
     final opt1 = CoapOption(OptionType.uriHost);
     expect(
       () => CoapOption.create(OptionType.fromTypeNumber(9000)),
@@ -93,22 +92,14 @@ void main() {
     expect(message.optionMap.length, 0);
   });
 
-  test('Message codes', () {
-    final message = CoapMessage();
-    expect(message.isRequest, isFalse);
-    expect(message.isResponse, isFalse);
-    expect(message.isEmpty, isFalse);
-    expect(message.isValid, isFalse);
-    expect(message.codeString, 'Not Set');
-  });
-
   test('Acknowledged', () {
     var acked = false;
     void ackHook() {
       acked = true;
     }
 
-    final message = CoapMessage()..isAcknowledged = true;
+    final message = CoapEmptyMessage(CoapMessageType.rst)
+      ..isAcknowledged = true;
     expect(message.isAcknowledged, isTrue);
     expect(acked, isFalse);
     final eventBus = CoapEventBus(namespace: '');
@@ -123,7 +114,7 @@ void main() {
   });
 
   test('Rejected', () {
-    final message = CoapMessage()..isRejected = true;
+    final message = CoapEmptyMessage(CoapMessageType.rst)..isRejected = true;
     expect(message.isRejected, isTrue);
     final eventBus = CoapEventBus(namespace: '');
     expect(eventBus.lastEvent is CoapRejectedEvent, isTrue);
@@ -135,7 +126,7 @@ void main() {
       timedOut = true;
     }
 
-    final message = CoapMessage()..isTimedOut = true;
+    final message = CoapEmptyMessage(CoapMessageType.rst)..isTimedOut = true;
     expect(message.isTimedOut, isTrue);
     expect(timedOut, isFalse);
     final eventBus = CoapEventBus(namespace: '');
@@ -150,7 +141,7 @@ void main() {
   });
 
   test('Retransmitting', () {
-    final message = CoapMessage();
+    final message = CoapEmptyMessage(CoapMessageType.rst)..isTimedOut = true;
     var retrans = false;
     void retransHook() {
       retrans = true;
@@ -165,14 +156,16 @@ void main() {
   });
 
   test('Payload', () {
-    final message = CoapMessage()..setPayload('This is the payload');
+    final message = CoapEmptyMessage(CoapMessageType.rst)
+      ..isTimedOut = true
+      ..setPayload('This is the payload');
     expect(message.payload, isNotNull);
     expect(message.payloadString, 'This is the payload');
     expect(message.payloadSize, 19);
   });
 
   test('If match', () {
-    final message = CoapMessage();
+    final message = CoapEmptyMessage(CoapMessageType.rst)..isTimedOut = true;
     expect(message.ifMatches.length, 0);
     message
       ..addIfMatch('ETag-1')
@@ -195,7 +188,7 @@ void main() {
   });
 
   test('ETags', () {
-    final message = CoapMessage();
+    final message = CoapEmptyMessage(CoapMessageType.rst)..isTimedOut = true;
     expect(message.etags.length, 0);
     final none = CoapOption(OptionType.ifMatch);
     final etag1 = CoapOption(OptionType.eTag)..stringValue = 'Etag-1';
@@ -219,7 +212,7 @@ void main() {
   });
 
   test('If None match', () {
-    final message = CoapMessage();
+    final message = CoapEmptyMessage(CoapMessageType.rst)..isTimedOut = true;
     expect(message.ifNoneMatches.length, 0);
     final none = CoapOption(OptionType.ifMatch);
     final inm1 = CoapOption(OptionType.ifNoneMatch)..stringValue = 'Inm1';
@@ -240,7 +233,7 @@ void main() {
   });
 
   test('Uri path', () {
-    final message = CoapMessage();
+    final message = CoapEmptyMessage(CoapMessageType.rst)..isTimedOut = true;
     expect(message.uriPaths.length, 0);
     for (final path in ['/a/uri/path', 'a/uri/path/', '/a/uri/path/']) {
       message.uriPath = path;
@@ -277,7 +270,7 @@ void main() {
   });
 
   test('Uri query', () {
-    final message = CoapMessage();
+    final message = CoapEmptyMessage(CoapMessageType.rst);
     expect(message.uriQueries.length, 0);
     message.uriQuery = 'a&uri=1&query=2';
     expect(message.uriQueries.length, 3);
@@ -303,7 +296,7 @@ void main() {
   });
 
   test('Location path', () {
-    final message = CoapMessage();
+    final message = CoapEmptyMessage(CoapMessageType.rst);
     expect(message.locationPaths.length, 0);
     message.locationPath = 'a/location/path/';
     expect(message.locationPaths.length, 3);
@@ -340,7 +333,7 @@ void main() {
   });
 
   test('Location query', () {
-    final message = CoapMessage();
+    final message = CoapEmptyMessage(CoapMessageType.rst);
     expect(message.locationQueries.length, 0);
     message.locationQuery = 'a&uri=1&query=2';
     expect(message.locationQueries.length, 3);

--- a/test/coap_message_encode_decode_test.dart
+++ b/test/coap_message_encode_decode_test.dart
@@ -170,7 +170,7 @@ void main() {
     }
 
     void testMessage(final CoapISpec spec, final int testNo) {
-      final CoapMessage msg = CoapRequest(CoapCode.methodGET)
+      final CoapMessage msg = CoapRequest(CoapCode.get)
         ..id = 12345
         ..payload = (typed.Uint8Buffer()..addAll('payload'.codeUnits));
       final data = spec.encode(msg)!;
@@ -188,7 +188,7 @@ void main() {
     }
 
     void testMessageWithOptions(final CoapISpec spec, final int testNo) {
-      final CoapMessage msg = CoapRequest(CoapCode.methodGET)
+      final CoapMessage msg = CoapRequest(CoapCode.get)
         ..id = 12345
         ..payload = (typed.Uint8Buffer()..addAll('payload'.codeUnits))
         ..addOption(
@@ -227,7 +227,7 @@ void main() {
     }
 
     void testMessageWithExtendedOption(final CoapISpec spec, final int testNo) {
-      final CoapMessage msg = CoapRequest(CoapCode.methodGET)
+      final CoapMessage msg = CoapRequest(CoapCode.get)
         ..id = 12345
         ..addOption(CoapOption.createVal(OptionType.contentFormat, 0));
       expect(msg.getFirstOption(OptionType.contentFormat)!.value, 0);
@@ -256,7 +256,7 @@ void main() {
     }
 
     void testRequestParsing(final CoapISpec spec, final int testNo) {
-      final request = CoapRequest(CoapCode.methodPOST, confirmable: false)
+      final request = CoapRequest(CoapCode.post, confirmable: false)
         ..id = 7
         ..token = (typed.Uint8Buffer()..addAll(<int>[11, 82, 165, 77, 3]))
         ..addIfMatchOpaque(typed.Uint8Buffer()..addAll(<int>[34, 239]))
@@ -287,8 +287,10 @@ void main() {
     }
 
     void testResponseParsing(final CoapISpec spec, final int testNo) {
-      final response = CoapResponse(CoapCode.content)
-        ..type = CoapMessageType.non
+      final response = CoapResponse(
+        CoapCode.content,
+        CoapMessageType.non,
+      )
         ..id = 9
         ..token = (typed.Uint8Buffer()..addAll(<int>[22, 255, 0, 78, 100, 22]))
         ..addETagOpaque(typed.Uint8Buffer()..addAll(<int>[1, 0, 0, 0, 0, 1]))


### PR DESCRIPTION
This PR refactors the `CoapCode` and `CoapMessageType` classes as enhanced enums (also see #80), making the code more concise and readable. The changes also make it easier to add more `CoapCode`s in the future. The PR itself adds a few missing `CoapCode`s from the IANA registry, including the new method codes `FETCH`, `PATCH`, and `iPATCH`.

CC @JosefWN 