### PR TITLE
fix!: upgrade `dart_tinydtls`, use `Uint8List` for `PskCredentials` instead of `String`

### DIFF
--- a/example/get_resource_secure.dart
+++ b/example/get_resource_secure.dart
@@ -15,12 +15,18 @@
  */
 
 import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
 import 'package:coap/coap.dart';
 
-final pskCredentials =
-    PskCredentials(identity: 'Client_identity', preSharedKey: 'secretPSK');
+final identity = Uint8List.fromList(utf8.encode('Client_identity'));
+final preSharedKey = Uint8List.fromList(utf8.encode('secretPSK'));
 
-PskCredentials pskCredentialsCallback(final String indentity) => pskCredentials;
+final pskCredentials =
+    PskCredentials(identity: identity, preSharedKey: preSharedKey);
+
+PskCredentials pskCredentialsCallback(final Uint8List indentity) =>
+    pskCredentials;
 
 class DtlsConfig extends DefaultCoapConfig {
   @override

--- a/lib/src/network/credentials/psk_credentials.dart
+++ b/lib/src/network/credentials/psk_credentials.dart
@@ -5,13 +5,16 @@
  * Copyright :  Jan Romann
  */
 
+import 'dart:typed_data';
+
 /// Function signature for a callback function for retrieving/generating
 /// [PskCredentials].
 ///
 /// As the format of the [identityHint] is not well-defined, this parameter
 /// can probably be ignored in most cases, when both the identity and the key
 /// are known in advance.
-typedef PskCredentialsCallback = PskCredentials Function(String identityHint);
+typedef PskCredentialsCallback = PskCredentials Function(
+    Uint8List identityHint);
 
 /// Credentials used for PSK Cipher Suites consisting of an [identity]
 /// and a [preSharedKey].
@@ -19,9 +22,9 @@ typedef PskCredentialsCallback = PskCredentials Function(String identityHint);
 /// Currently, only the mandatory Cipher Suite `TLS_PSK_WITH_AES_128_CCM_8` is
 /// supported via tinydtls.
 class PskCredentials {
-  String identity;
+  Uint8List identity;
 
-  String preSharedKey;
+  Uint8List preSharedKey;
 
   PskCredentials({required this.identity, required this.preSharedKey});
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   build: ^2.3.0
   collection: ^1.16.0
   convert: ^3.0.2
-  dart_tinydtls: ^2.0.0
+  dart_tinydtls: ^3.1.0
   dtls: ^0.1.0
   event_bus: ^2.0.0
   meta: ^1.8.0


### PR DESCRIPTION
Due to the fact that not all PSK credentials consist of UTF-8 strings, the API in dart_tinydtls to accept `Uint8List`s as parameters instead of `String`s.

This PR updates the CoAP API accordingly, while also upgrading dart_tinydtls to the latest version, which also fixes some issues with connections that are closed by a peer due to an error.