### PR TITLE
fix: allow empty URI path segments in requests

### DIFF
--- a/lib/src/coap_message.dart
+++ b/lib/src/coap_message.dart
@@ -625,8 +625,14 @@ abstract class CoapMessage {
 
   /// Set the location path from a string
   set locationPath(final String fullPath) {
-    final trimmedPath = _trimChar(fullPath, '/');
     clearLocationPath();
+
+    var trimmedPath = fullPath;
+
+    if (fullPath.startsWith('/')) {
+      trimmedPath = fullPath.substring(1);
+    }
+
     trimmedPath.split('/').forEach(addLocationPath);
   }
 

--- a/lib/src/coap_message.dart
+++ b/lib/src/coap_message.dart
@@ -496,8 +496,12 @@ abstract class CoapMessage {
   }
 
   /// URI path
+  // TODO: Apply proper percent-encoding
   String get uriPath =>
-      CoapOption.join(getOptions(OptionType.uriPath), '/') ?? '';
+      getOptions(OptionType.uriPath)
+          ?.map((final e) => e.stringValue.replaceAll('/', '%2F'))
+          .join('/') ??
+      '';
 
   /// Sets a number of Uri path options from a string
   set uriPath(final String fullPath) {
@@ -521,22 +525,21 @@ abstract class CoapMessage {
 
   /// Add a URI path
   void addUriPath(final String path) {
-    final trimmedPath = _trimChar(path, '/');
-    if (trimmedPath.contains('/')) {
+    if (path == '.' || path == '..') {
       throw ArgumentError.value(
         path,
         'Message::addUriPath',
-        'A single Uri Path can only contain leading or trailing slashes',
+        'The value of a Uri-Path Option must not be "." or ".."',
       );
     }
-    if (trimmedPath.length > 255) {
+    if (path.length > 255) {
       throw ArgumentError.value(
-        trimmedPath.length,
+        path.length,
         'Message::addUriPath',
         "Uri Path option's length must be between 0 and 255 inclusive",
       );
     }
-    addOption(CoapOption.createString(OptionType.uriPath, trimmedPath));
+    addOption(CoapOption.createString(OptionType.uriPath, path));
   }
 
   /// Remove a URI path
@@ -552,8 +555,12 @@ abstract class CoapMessage {
   void clearUriPath() => removeOptions(OptionType.uriPath);
 
   /// URI query
+  // TODO: Apply proper percent-encoding
   String get uriQuery =>
-      CoapOption.join(getOptions(OptionType.uriQuery), '&') ?? '';
+      getOptions(OptionType.uriQuery)
+          ?.map((final option) => option.stringValue.replaceAll('&', '%26'))
+          .join('&') ??
+      '';
 
   /// Set a URI query
   set uriQuery(final String fullQuery) {
@@ -570,17 +577,9 @@ abstract class CoapMessage {
 
   /// Add a URI query
   void addUriQuery(final String query) {
-    final trimmedQuery = _trimChar(query, '&');
-    if (trimmedQuery.contains('&')) {
+    if (query.length > 255) {
       throw ArgumentError.value(
-        query,
-        'Message::addUriQuery',
-        'A single Uri Query can only contain leading or trailing &',
-      );
-    }
-    if (trimmedQuery.length > 255) {
-      throw ArgumentError.value(
-        trimmedQuery.length,
+        query.length,
         'Message::addUriQuery',
         "Uri Query option's length must be between 0 and 255 inclusive",
       );
@@ -612,16 +611,12 @@ abstract class CoapMessage {
   }
 
   /// Location path as a string
-  String get locationPath {
-    final sb = StringBuffer();
-    for (final option in locationPaths) {
-      sb.write(option.stringValue);
-      if (option != locationPaths.last) {
-        sb.write('/');
-      }
-    }
-    return sb.toString();
-  }
+  // TODO: Apply proper percent-encoding
+  String get locationPath =>
+      getOptions(OptionType.locationPath)
+          ?.map((final option) => option.stringValue.replaceAll('/', '%2F'))
+          .join('/') ??
+      '';
 
   /// Set the location path from a string
   set locationPath(final String fullPath) {
@@ -651,29 +646,21 @@ abstract class CoapMessage {
 
   /// Add a location path
   void addLocationPath(final String path) {
-    final trimmedPath = _trimChar(path, '/');
-    if (trimmedPath == '..' || trimmedPath == '.') {
+    if (path == '..' || path == '.') {
       throw ArgumentError.value(
         path,
         'Message::addLocationPath'
-        "A Location Path must not be only '.' or '..'",
+        'The value of a Location-Path Option must not be "." or ".."',
       );
     }
-    if (trimmedPath.contains('/')) {
+    if (path.length > 255) {
       throw ArgumentError.value(
-        path,
-        'Message::addLocationPath',
-        'A single Location Path can only contain leading or trailing slashes',
-      );
-    }
-    if (trimmedPath.length > 255) {
-      throw ArgumentError.value(
-        trimmedPath.length,
+        path.length,
         'Message::addLocationPath',
         "Location Path option's length must be between 0 and 255 inclusive",
       );
     }
-    addOption(CoapOption.createString(OptionType.locationPath, trimmedPath));
+    addOption(CoapOption.createString(OptionType.locationPath, path));
   }
 
   /// Remove a location path
@@ -689,8 +676,12 @@ abstract class CoapMessage {
   void clearLocationPath() => _optionMap.remove(OptionType.locationPath);
 
   /// Location query
+  // TODO: Apply proper percent-encoding
   String get locationQuery =>
-      CoapOption.join(getOptions(OptionType.locationQuery), '&') ?? '';
+      getOptions(OptionType.locationQuery)
+          ?.map((final e) => e.stringValue.replaceAll('&', '%26'))
+          .join('&') ??
+      '';
 
   /// Set a location query
   set locationQuery(final String fullQuery) {
@@ -708,20 +699,12 @@ abstract class CoapMessage {
 
   /// Add a location query
   void addLocationQuery(final String query) {
-    final trimmedQuery = _trimChar(query, '&');
-    if (trimmedQuery.length > 255) {
+    if (query.length > 255) {
       throw ArgumentError.value(
-        trimmedQuery.length,
+        query.length,
         'Message::addLocationQuery',
         "Location Query option's length must be between "
             '0 and 255 inclusive',
-      );
-    }
-    if (trimmedQuery.contains('&')) {
-      throw ArgumentError.value(
-        query,
-        'Message::addLocationQuery',
-        'A single Location Query can only contain leading or trailing &',
       );
     }
     addOption(CoapOption.createString(OptionType.locationQuery, query));
@@ -978,18 +961,5 @@ abstract class CoapMessage {
       str = value.toString();
     }
     return str != '' ? '  $name: $str,\n' : '';
-  }
-
-  String _trimChar(final String str, final String char) {
-    var trimmed = str;
-    if (trimmed.startsWith(char)) {
-      trimmed = trimmed.substring(1);
-    }
-
-    if (trimmed.endsWith('/')) {
-      trimmed = trimmed.substring(0, trimmed.length - 1);
-    }
-
-    return trimmed;
   }
 }

--- a/lib/src/coap_message.dart
+++ b/lib/src/coap_message.dart
@@ -557,7 +557,7 @@ abstract class CoapMessage {
 
   /// Set a URI query
   set uriQuery(final String fullQuery) {
-    var trimmedQuery = _trimChar(fullQuery, '&');
+    var trimmedQuery = fullQuery;
     if (trimmedQuery.startsWith('?')) {
       trimmedQuery = trimmedQuery.substring(1);
     }

--- a/lib/src/coap_message.dart
+++ b/lib/src/coap_message.dart
@@ -694,7 +694,7 @@ abstract class CoapMessage {
 
   /// Set a location query
   set locationQuery(final String fullQuery) {
-    var trimmedQuery = _trimChar(fullQuery, '&');
+    var trimmedQuery = fullQuery;
     if (trimmedQuery.startsWith('?')) {
       trimmedQuery = trimmedQuery.substring(1);
     }

--- a/lib/src/coap_message.dart
+++ b/lib/src/coap_message.dart
@@ -499,10 +499,20 @@ abstract class CoapMessage {
   String get uriPath =>
       CoapOption.join(getOptions(OptionType.uriPath), '/') ?? '';
 
-  /// Sets a number of Uri path options from a string, trims /
+  /// Sets a number of Uri path options from a string
   set uriPath(final String fullPath) {
-    final trimmedPath = _trimChar(fullPath, '/');
     clearUriPath();
+
+    var trimmedPath = fullPath;
+
+    if (fullPath.startsWith('/')) {
+      trimmedPath = fullPath.substring(1);
+    }
+
+    if (trimmedPath.isEmpty) {
+      return;
+    }
+
     trimmedPath.split('/').forEach(addUriPath);
   }
 

--- a/test/coap_message_api_test.dart
+++ b/test/coap_message_api_test.dart
@@ -302,15 +302,21 @@ void main() {
   test('Location path', () {
     final message = CoapEmptyMessage(CoapMessageType.rst);
     expect(message.locationPaths.length, 0);
+    message.locationPath = '';
+    expect(message.locationPaths.length, 1);
+    expect(message.locationPath, '');
+    message.locationPath = '/';
+    expect(message.locationPaths.length, 1);
+    expect(message.locationPath, '');
     message.locationPath = 'a/location/path/';
-    expect(message.locationPaths.length, 3);
-    expect(message.locationPath, 'a/location/path');
-    message.addLocationPath('longer');
     expect(message.locationPaths.length, 4);
-    expect(message.locationPath, 'a/location/path/longer');
+    expect(message.locationPath, 'a/location/path/');
+    message.addLocationPath('longer');
+    expect(message.locationPaths.length, 5);
+    expect(message.locationPath, 'a/location/path//longer');
     message.removelocationPath('path');
-    expect(message.locationPaths.length, 3);
-    expect(message.locationPath, 'a/location/longer');
+    expect(message.locationPaths.length, 4);
+    expect(message.locationPath, 'a/location//longer');
     message.clearLocationPath();
     expect(message.locationPaths.length, 0);
     expect(message.locationPath.isEmpty, isTrue);

--- a/test/coap_message_api_test.dart
+++ b/test/coap_message_api_test.dart
@@ -235,14 +235,18 @@ void main() {
   test('Uri path', () {
     final message = CoapEmptyMessage(CoapMessageType.rst)..isTimedOut = true;
     expect(message.uriPaths.length, 0);
-    for (final path in ['/a/uri/path', 'a/uri/path/', '/a/uri/path/']) {
+    for (final path in ['', '/']) {
       message.uriPath = path;
-      expect(message.uriPaths.length, 3);
-      expect(message.uriPath, 'a/uri/path');
+      expect(message.uriPaths.length, 0);
+    }
+    for (final path in ['a/uri/path/', '/a/uri/path/']) {
+      message.uriPath = path;
+      expect(message.uriPaths.length, 4);
+      expect(message.uriPath, 'a/uri/path/');
     }
     message.addUriPath('longer');
-    expect(message.uriPaths.length, 4);
-    expect(message.uriPath, 'a/uri/path/longer');
+    expect(message.uriPaths.length, 5);
+    expect(message.uriPath, 'a/uri/path//longer');
     expect(
       () => message.addUriPath('multiple/not/allowed'),
       throwsArgumentError,
@@ -254,8 +258,8 @@ void main() {
     final tooLong = 'n' * 1000;
     expect(() => message.addUriPath(tooLong), throwsArgumentError);
     message.removeUriPath('path');
-    expect(message.uriPaths.length, 3);
-    expect(message.uriPath, 'a/uri/longer');
+    expect(message.uriPaths.length, 4);
+    expect(message.uriPath, 'a/uri//longer');
     message.clearUriPath();
     expect(message.uriPaths.length, 0);
     expect(message.uriPath.isEmpty, isTrue);

--- a/test/coap_message_api_test.dart
+++ b/test/coap_message_api_test.dart
@@ -247,19 +247,15 @@ void main() {
     message.addUriPath('longer');
     expect(message.uriPaths.length, 5);
     expect(message.uriPath, 'a/uri/path//longer');
-    expect(
-      () => message.addUriPath('multiple/not/allowed'),
-      throwsArgumentError,
-    );
-    expect(
-      () => message.addLocationPath('no-double-slash//'),
-      throwsArgumentError,
-    );
+    message.addUriPath('multiple/are/allowed');
+    expect(message.uriPath, 'a/uri/path//longer/multiple%2Fare%2Fallowed');
+    message.addLocationPath('no-double-slash//');
+    expect(message.uriPath, 'a/uri/path//longer/multiple%2Fare%2Fallowed');
     final tooLong = 'n' * 1000;
     expect(() => message.addUriPath(tooLong), throwsArgumentError);
     message.removeUriPath('path');
-    expect(message.uriPaths.length, 4);
-    expect(message.uriPath, 'a/uri//longer');
+    expect(message.uriPaths.length, 5);
+    expect(message.uriPath, 'a/uri//longer/multiple%2Fare%2Fallowed');
     message.clearUriPath();
     expect(message.uriPaths.length, 0);
     expect(message.uriPath.isEmpty, isTrue);
@@ -284,17 +280,22 @@ void main() {
     expect(message.uriQuery, 'a&uri=1&query=2&longer=3');
     final tooLong = 'n' * 1000;
     expect(() => message.addUriQuery(tooLong), throwsArgumentError);
+    message.addUriQuery('allow=1&multiple=2&queries=3');
     expect(
-      () => message.addUriQuery('no=1&multiple=2&queries=3'),
-      throwsArgumentError,
+      message.uriQuery,
+      'a&uri=1&query=2&longer=3&allow=1%26multiple=2%26queries=3',
     );
+    message.addLocationQuery('no_double_and=1&&');
     expect(
-      () => message.addLocationQuery('no_double_and=1&&'),
-      throwsArgumentError,
+      message.uriQuery,
+      'a&uri=1&query=2&longer=3&allow=1%26multiple=2%26queries=3',
     );
     message.removeUriQuery('query=2');
-    expect(message.uriQueries.length, 3);
-    expect(message.uriQuery, 'a&uri=1&longer=3');
+    expect(message.uriQueries.length, 4);
+    expect(
+      message.uriQuery,
+      'a&uri=1&longer=3&allow=1%26multiple=2%26queries=3',
+    );
     message.clearUriQuery();
     expect(message.uriQueries.length, 0);
   });
@@ -330,14 +331,10 @@ void main() {
     expect(message.locationPath, '');
     expect(() => message.locationPath = '..', throwsArgumentError);
     expect(() => message.locationPath = '.', throwsArgumentError);
-    expect(
-      () => message.addLocationPath('multiple/not/allowed'),
-      throwsArgumentError,
-    );
-    expect(
-      () => message.addLocationPath('no-double-slash//'),
-      throwsArgumentError,
-    );
+    message.addLocationPath('multiple/are/allowed');
+    expect(message.locationPaths.length, 1);
+    message.addLocationPath('double-slash//');
+    expect(message.locationPaths.length, 2);
     final tooLong = 'n' * 1000;
     expect(() => message.addLocationPath(tooLong), throwsArgumentError);
   });
@@ -353,17 +350,23 @@ void main() {
     expect(message.locationQuery, 'a&uri=1&query=2&longer=3');
     final tooLong = 'n' * 1000;
     expect(() => message.addLocationQuery(tooLong), throwsArgumentError);
+    message.addLocationQuery('allow=1&multiple=2&queries=3');
     expect(
-      () => message.addLocationQuery('no=1&multiple=2&queries=3'),
-      throwsArgumentError,
+      message.locationQuery,
+      'a&uri=1&query=2&longer=3&allow=1%26multiple=2%26queries=3',
     );
+    message.addLocationQuery('double_and=1&&');
     expect(
-      () => message.addLocationQuery('no_double_and=1&&'),
-      throwsArgumentError,
+      message.locationQuery,
+      'a&uri=1&query=2&longer=3&allow=1%26multiple=2%26queries=3'
+      '&double_and=1%26%26',
     );
     message.removeLocationQuery('query=2');
-    expect(message.locationQueries.length, 3);
-    expect(message.locationQuery, 'a&uri=1&longer=3');
+    expect(message.locationQueries.length, 5);
+    expect(
+      message.locationQuery,
+      'a&uri=1&longer=3&allow=1%26multiple=2%26queries=3&double_and=1%26%26',
+    );
     message.clearLocationQuery();
     expect(message.locationQueries.length, 0);
   });


### PR DESCRIPTION
Interacting with other CoAP libraries, we noticed in my project that URI paths seem to not be converted into options correctly. In particular, it seems as if empty URI path segments are supposed to be converted into empty URI-path options. Currently, these empty segments are removed from the URI path completely.

This PR adjusts the corresponding creation method accordingly, which should also make the library's behavior more consistent with [section 6.4 of RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252#section-6.4).