### PR TITLE
feat: refactor option number decoding, add missing option codes

### DIFF
--- a/lib/src/coap_option_type.dart
+++ b/lib/src/coap_option_type.dart
@@ -5,7 +5,8 @@
  * Copyright :  S.Hamblett
  */
 
-// Option numbers
+import 'dart:collection';
+
 const _ifMatch = 1;
 const _uriHost = 3;
 const _eTag = 4;
@@ -114,53 +115,22 @@ enum OptionType implements Comparable<OptionType> {
   final OptionFormat optionFormat;
   const OptionType(this.optionNumber, this.optionName, this.optionFormat);
 
+  static final _registry = HashMap.fromEntries(
+    values.map((final value) => MapEntry(value.optionNumber, value)),
+  );
+
   /// Creates a new [OptionType] object from a numeric [type].
   static OptionType fromTypeNumber(final int type) {
-    switch (type) {
-      case _ifMatch:
-        return OptionType.ifMatch;
-      case _uriHost:
-        return OptionType.uriHost;
-      case _eTag:
-        return OptionType.eTag;
-      case _ifNoneMatch:
-        return OptionType.ifNoneMatch;
-      case _observe:
-        return OptionType.observe;
-      case _uriPort:
-        return OptionType.uriPort;
-      case _locationPath:
-        return OptionType.locationPath;
-      case _uriPath:
-        return OptionType.uriPath;
-      case _contentFormat:
-        return OptionType.contentFormat;
-      case _maxAge:
-        return OptionType.maxAge;
-      case _uriQuery:
-        return OptionType.uriQuery;
-      case _accept:
-        return OptionType.accept;
-      case _locationQuery:
-        return OptionType.locationQuery;
-      case _block2:
-        return OptionType.block2;
-      case _block1:
-        return OptionType.block1;
-      case _size2:
-        return OptionType.size2;
-      case _proxyUri:
-        return OptionType.proxyUri;
-      case _proxyScheme:
-        return OptionType.proxyScheme;
-      case _size1:
-        return OptionType.size1;
-      default:
-        if (type.isOdd) {
-          throw UnknownCriticalOptionException(type);
-        } else {
-          throw UnknownElectiveOptionException(type);
-        }
+    final optionType = _registry[type];
+
+    if (optionType != null) {
+      return optionType;
+    }
+
+    if (type.isOdd) {
+      throw UnknownCriticalOptionException(type);
+    } else {
+      throw UnknownElectiveOptionException(type);
     }
   }
 

--- a/lib/src/coap_option_type.dart
+++ b/lib/src/coap_option_type.dart
@@ -58,6 +58,12 @@ enum OptionType implements Comparable<OptionType> {
   /// E, String, 1-270 B, -
   locationPath(8, 'Location-Path', OptionFormat.string),
 
+  /// C, String, 0-255 B, -
+  ///
+  /// Defined in [RFC 8613](https://datatracker.ietf.org/doc/html/rfc8613).
+  // TODO(JKRhb): Option format should be revisited.
+  oscore(9, 'OSCORE', OptionFormat.opaque),
+
   /// C, String, 1-270 B, ""
   uriPath(11, 'Uri-Path', OptionFormat.string),
 
@@ -70,8 +76,29 @@ enum OptionType implements Comparable<OptionType> {
   /// C, String, 1-270 B, ""
   uriQuery(15, 'Uri-Query', OptionFormat.string),
 
+  /// E, uint, 1 B, 16
+  ///
+  /// Defined in [RFC 8768](https://datatracker.ietf.org/doc/html/rfc8768).
+  hopLimit(16, 'Hop-Limit', OptionFormat.integer),
+
   /// C, Sequence of Bytes, 1-n B, -
   accept(17, 'Accept', OptionFormat.integer),
+
+  /// C, uint, 0-3 B, -
+  ///
+  /// Defined in [RFC 9177](https://datatracker.ietf.org/doc/html/rfc9177).
+  qBlock1(19, 'Q-Block1', OptionFormat.integer),
+
+  /// C, empty, 0 B, -
+  ///
+  /// Defined in [draft-ietf-core-oscore-edhoc-02].
+  ///
+  /// Note: The registration of this option is only temporary at the moment
+  /// and might be removed by IANA if draft-ietf-core-oscore-edhoc does not
+  /// become an RFC.
+  ///
+  /// [draft-ietf-core-oscore-edhoc-04]: https://datatracker.ietf.org/doc/html/draft-ietf-core-oscore-edhoc-04#section-3.1
+  edhoc(21, 'EDHOC', OptionFormat.empty),
 
   /// E, String, 1-270 B, -
   locationQuery(20, 'Location-Query', OptionFormat.string),
@@ -79,11 +106,54 @@ enum OptionType implements Comparable<OptionType> {
   block1(27, 'Block1', OptionFormat.integer),
   size2(28, 'Size2', OptionFormat.integer),
 
+  /// C, uint, 0-3 B, -
+  ///
+  /// Defined in [RFC 9177](https://datatracker.ietf.org/doc/html/rfc9177).
+  qBlock2(31, 'Q-Block2', OptionFormat.integer),
+
   /// C, String, 1-270 B, "coap"
   proxyUri(35, 'Proxy-Uri', OptionFormat.string),
 
   proxyScheme(39, 'Proxy-Scheme', OptionFormat.string),
-  size1(60, 'Size1', OptionFormat.integer);
+  size1(60, 'Size1', OptionFormat.integer),
+
+  /// E, opaque, 1-40 B, -
+  ///
+  /// Defined in [RFC 9175](https://datatracker.ietf.org/doc/html/rfc9175).
+  echo(252, 'Echo', OptionFormat.opaque),
+
+  /// E, uint, 0-1 B, 0
+  ///
+  /// Defined in [RFC 7967](https://datatracker.ietf.org/doc/html/rfc7967),
+  /// updated by [RFC 8613](https://datatracker.ietf.org/doc/html/rfc8613).
+  noResponse(258, 'No-Response', OptionFormat.integer),
+
+  /// E, opaque, 0-8 B, -
+  ///
+  /// Defined in [RFC 9175](https://datatracker.ietf.org/doc/html/rfc9175).
+  requestTag(292, 'Request-Tag', OptionFormat.opaque),
+
+  /// C, uint, 2 B, -
+  ///
+  /// Defined in the [OCF Core Specification v1.3.0 Part 1], page 128.
+  ///
+  /// [OCF Core Specification v1.3.0]: https://openconnectivity.org/specs/OCF_Core_Specification_v1.3.0.pdf
+  ocfAcceptContentFormatVersion(
+    2049,
+    'OCF-Accept-Content-Format-Version',
+    OptionFormat.integer,
+  ),
+
+  /// C, uint, 2 B, -
+  ///
+  /// Defined in the [OCF Core Specification v1.3.0 Part 1], page 128.
+  ///
+  /// [OCF Core Specification v1.3.0]: https://openconnectivity.org/specs/OCF_Core_Specification_v1.3.0.pdf
+  ocfContentFormatVersion(
+    2053,
+    'OCF-Content-Format-Version',
+    OptionFormat.integer,
+  );
 
   /// The number of this option.
   final int optionNumber;

--- a/lib/src/coap_option_type.dart
+++ b/lib/src/coap_option_type.dart
@@ -7,26 +7,6 @@
 
 import 'dart:collection';
 
-const _ifMatch = 1;
-const _uriHost = 3;
-const _eTag = 4;
-const _ifNoneMatch = 5;
-const _observe = 6;
-const _uriPort = 7;
-const _locationPath = 8;
-const _uriPath = 11;
-const _contentFormat = 12;
-const _maxAge = 14;
-const _uriQuery = 15;
-const _accept = 17;
-const _locationQuery = 20;
-const _block2 = 23;
-const _block1 = 27;
-const _size2 = 28;
-const _proxyUri = 35;
-const _proxyScheme = 39;
-const _size1 = 60;
-
 /// Base class for [Exception]s that are thrown when an unknown CoapOption
 /// number is encountered during the parsing of a CoapMessage.
 abstract class UnknownOptionException implements Exception {
@@ -59,51 +39,51 @@ class UnknownCriticalOptionException extends UnknownOptionException {
 /// RFC 7252, Section 12.2 and other CoAP extensions.
 enum OptionType implements Comparable<OptionType> {
   /// C, opaque, 0-8 B, -
-  ifMatch(_ifMatch, 'If-Match', OptionFormat.opaque),
+  ifMatch(1, 'If-Match', OptionFormat.opaque),
 
   /// C, String, 1-270 B, ""
-  uriHost(_uriHost, 'Uri-Host', OptionFormat.string),
+  uriHost(3, 'Uri-Host', OptionFormat.string),
 
   /// E, sequence of bytes, 1-4 B, -
-  eTag(_eTag, 'ETag', OptionFormat.opaque),
+  eTag(4, 'ETag', OptionFormat.opaque),
 
-  ifNoneMatch(_ifNoneMatch, 'If-None-Match', OptionFormat.empty),
+  ifNoneMatch(5, 'If-None-Match', OptionFormat.empty),
 
   /// E, Duration, 1 B, 0
-  observe(_observe, 'Observe', OptionFormat.integer),
+  observe(6, 'Observe', OptionFormat.integer),
 
   /// C, uint, 0-2 B
-  uriPort(_uriPort, 'Uri-Port', OptionFormat.integer),
+  uriPort(7, 'Uri-Port', OptionFormat.integer),
 
   /// E, String, 1-270 B, -
-  locationPath(_locationPath, 'Location-Path', OptionFormat.string),
+  locationPath(8, 'Location-Path', OptionFormat.string),
 
   /// C, String, 1-270 B, ""
-  uriPath(_uriPath, 'Uri-Path', OptionFormat.string),
+  uriPath(11, 'Uri-Path', OptionFormat.string),
 
   /// C, 8-bit uint, 1 B, 0 (text/plain)
-  contentFormat(_contentFormat, 'Content-Format', OptionFormat.integer),
+  contentFormat(12, 'Content-Format', OptionFormat.integer),
 
   /// E, variable length, 1--4 B, 60 Seconds
-  maxAge(_maxAge, 'Max-Age', OptionFormat.integer),
+  maxAge(14, 'Max-Age', OptionFormat.integer),
 
   /// C, String, 1-270 B, ""
-  uriQuery(_uriQuery, 'Uri-Query', OptionFormat.string),
+  uriQuery(15, 'Uri-Query', OptionFormat.string),
 
   /// C, Sequence of Bytes, 1-n B, -
-  accept(_accept, 'Accept', OptionFormat.integer),
+  accept(17, 'Accept', OptionFormat.integer),
 
   /// E, String, 1-270 B, -
-  locationQuery(_locationQuery, 'Location-Query', OptionFormat.string),
-  block2(_block2, 'Block2', OptionFormat.integer),
-  block1(_block1, 'Block1', OptionFormat.integer),
-  size2(_size2, 'Size2', OptionFormat.integer),
+  locationQuery(20, 'Location-Query', OptionFormat.string),
+  block2(23, 'Block2', OptionFormat.integer),
+  block1(27, 'Block1', OptionFormat.integer),
+  size2(28, 'Size2', OptionFormat.integer),
 
   /// C, String, 1-270 B, "coap"
-  proxyUri(_proxyUri, 'Proxy-Uri', OptionFormat.string),
+  proxyUri(35, 'Proxy-Uri', OptionFormat.string),
 
-  proxyScheme(_proxyScheme, 'Proxy-Scheme', OptionFormat.string),
-  size1(_size1, 'Size1', OptionFormat.integer);
+  proxyScheme(39, 'Proxy-Scheme', OptionFormat.string),
+  size1(60, 'Size1', OptionFormat.integer);
 
   /// The number of this option.
   final int optionNumber;


### PR DESCRIPTION
This PR applies a minor rework to the CoAP option code registry, simplifying the matching of codes to enum values. It also adds the remaining missing option codes from the IANA registry.