### PR TITLE
fix: don't set default Accept and Content-Format options

### DIFF
--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -313,7 +313,7 @@ class CoapClient {
     if (links.contentFormat != CoapMediaType.applicationLinkFormat) {
       return <CoapWebLink>[CoapWebLink('')];
     } else {
-      return CoapLinkFormat.parse(links.payloadString!);
+      return CoapLinkFormat.parse(links.payloadString);
     }
   }
 

--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -129,7 +129,7 @@ class CoapClient {
   /// Sends a GET request.
   Future<CoapResponse> get(
     final String path, {
-    final CoapMediaType accept = CoapMediaType.textPlain,
+    final CoapMediaType? accept,
     final bool confirmable = true,
     final List<CoapOption>? options,
     final bool earlyBlock2Negotiation = false,
@@ -152,8 +152,8 @@ class CoapClient {
   Future<CoapResponse> post(
     final String path, {
     required final String payload,
-    final CoapMediaType format = CoapMediaType.textPlain,
-    final CoapMediaType accept = CoapMediaType.textPlain,
+    final CoapMediaType? format,
+    final CoapMediaType? accept,
     final bool confirmable = true,
     final List<CoapOption>? options,
     final bool earlyBlock2Negotiation = false,
@@ -177,8 +177,8 @@ class CoapClient {
   Future<CoapResponse> postBytes(
     final String path, {
     required final Uint8Buffer payload,
-    final CoapMediaType format = CoapMediaType.textPlain,
-    final CoapMediaType accept = CoapMediaType.textPlain,
+    final CoapMediaType? format,
+    final CoapMediaType? accept,
     final bool confirmable = true,
     final List<CoapOption>? options,
     final bool earlyBlock2Negotiation = false,
@@ -202,8 +202,8 @@ class CoapClient {
   Future<CoapResponse> put(
     final String path, {
     required final String payload,
-    final CoapMediaType format = CoapMediaType.textPlain,
-    final CoapMediaType accept = CoapMediaType.textPlain,
+    final CoapMediaType? format,
+    final CoapMediaType? accept,
     final bool confirmable = true,
     final List<Uint8Buffer>? etags,
     final MatchEtags matchEtags = MatchEtags.onMatch,
@@ -231,10 +231,10 @@ class CoapClient {
   Future<CoapResponse> putBytes(
     final String path, {
     required final Uint8Buffer payload,
-    final CoapMediaType format = CoapMediaType.textPlain,
+    final CoapMediaType? format,
     final MatchEtags matchEtags = MatchEtags.onMatch,
     final List<Uint8Buffer>? etags,
-    final CoapMediaType accept = CoapMediaType.textPlain,
+    final CoapMediaType? accept,
     final bool confirmable = true,
     final List<CoapOption>? options,
     final bool earlyBlock2Negotiation = false,
@@ -259,7 +259,7 @@ class CoapClient {
   /// Sends a DELETE request
   Future<CoapResponse> delete(
     final String path, {
-    final CoapMediaType accept = CoapMediaType.textPlain,
+    final CoapMediaType? accept,
     final bool confirmable = true,
     final List<CoapOption>? options,
     final bool earlyBlock2Negotiation = false,
@@ -377,7 +377,7 @@ class CoapClient {
   void _build(
     final CoapRequest request,
     final String path,
-    final CoapMediaType accept,
+    final CoapMediaType? accept,
     final List<CoapOption>? options,
     final bool earlyBlock2Negotiation,
     final int maxRetransmit, {
@@ -413,9 +413,7 @@ class CoapClient {
     request
       ..uri = uri
       ..timestamp = DateTime.now()
-      ..eventBus = _eventBus
-      // Set a default accept
-      ..accept ??= CoapMediaType.textPlain;
+      ..eventBus = _eventBus;
 
     await _lock.synchronized(() async {
       // Set endpoint if missing

--- a/lib/src/coap_message.dart
+++ b/lib/src/coap_message.dart
@@ -289,7 +289,7 @@ abstract class CoapMessage {
   int get payloadSize => payload?.length ?? 0;
 
   /// The payload of this CoAP message in string representation.
-  String? get payloadString {
+  String get payloadString {
     final payload = this.payload;
     if (payload != null && payload.isNotEmpty) {
       try {
@@ -301,11 +301,11 @@ abstract class CoapMessage {
         return '<<<< Payload incomplete >>>>>';
       }
     }
-    return null;
+    return '';
   }
 
   /// Sets the payload from a string with a default media type
-  set payloadString(final String? value) =>
+  set payloadString(final String value) =>
       setPayloadMedia(value, CoapMediaType.textPlain);
 
   /// Sets the payload.
@@ -315,20 +315,17 @@ abstract class CoapMessage {
   }
 
   /// Sets the payload and media type of this CoAP message.
-  void setPayloadMedia(final String? payload, final CoapMediaType? mediaType) {
-    if (payload == null) {
-      return;
-    }
-    this.payload ??= Uint8Buffer();
-    this.payload!.addAll(_utfEncoder.convert(payload));
+  void setPayloadMedia(final String payload, [final CoapMediaType? mediaType]) {
+    final payloadBuffer = Uint8Buffer()..addAll(_utfEncoder.convert(payload));
+    this.payload = payloadBuffer;
     contentType = mediaType;
   }
 
   /// Sets the payload of this CoAP message.
   void setPayloadMediaRaw(
-    final Uint8Buffer payload,
+    final Uint8Buffer payload, [
     final CoapMediaType? mediaType,
-  ) {
+  ]) {
     this.payload = payload;
     contentType = mediaType;
   }

--- a/lib/src/coap_message.dart
+++ b/lib/src/coap_message.dart
@@ -315,7 +315,7 @@ abstract class CoapMessage {
   }
 
   /// Sets the payload and media type of this CoAP message.
-  void setPayloadMedia(final String? payload, final CoapMediaType mediaType) {
+  void setPayloadMedia(final String? payload, final CoapMediaType? mediaType) {
     if (payload == null) {
       return;
     }
@@ -327,7 +327,7 @@ abstract class CoapMessage {
   /// Sets the payload of this CoAP message.
   void setPayloadMediaRaw(
     final Uint8Buffer payload,
-    final CoapMediaType mediaType,
+    final CoapMediaType? mediaType,
   ) {
     this.payload = payload;
     contentType = mediaType;

--- a/test/coap_message_api_test.dart
+++ b/test/coap_message_api_test.dart
@@ -40,7 +40,7 @@ void main() {
     expect(message.ackTimeout, 0);
     expect(message.payload, isNull);
     expect(message.payloadSize, 0);
-    expect(message.payloadString, isNull);
+    expect(message.payloadString, '');
   });
 
   test('Options', () {


### PR DESCRIPTION
At the moment, both for the Accept and the Content-Format option, a default value of 0 (`text/plain; charset=utf-8`) is set for requests. This is a bit at odds with the CoAP specification, which assumes no default value for these two options and can lead to unintended side effects if a server rejects certain accept values (but would allow requests with no accept option set).

Therefore, this PR proposes removing the default values from the creation methods, giving full control to the library users.