### PR TITLE
feat: add constructors and client methods for new CoAP methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The CoAP library is an implementation in Dart providing a CoAP client, the code 
 * CoAP over UDP [RFC 7252](https://tools.ietf.org/html/rfc7252)
 * Observe resources [RFC 7641](https://tools.ietf.org/html/rfc7641)
 * Block-wise transfers [RFC 7959](https://tools.ietf.org/html/rfc7959)
+* FETCH, PATCH, and iPATCH methods [RFC 8132](https://www.rfc-editor.org/rfc/rfc8132.html)
 * Multicast over UDP (not DTLS)
 * **Experimental**: CoAP over DTLS (using FFI)
   * [dtls](https://pub.dev/packages/dtls) for OpenSSL

--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -278,6 +278,164 @@ class CoapClient {
     return send(request, onMulticastResponse: onMulticastResponse);
   }
 
+  /// Sends a FETCH request.
+  ///
+  /// See [RFC 8132, section 2].
+  ///
+  /// [RFC 8132, section 2]: https://www.rfc-editor.org/rfc/rfc8132.html#section-2
+  Future<CoapResponse> fetch(
+    final String path, {
+    final CoapMediaType? accept,
+    final bool confirmable = true,
+    final List<CoapOption>? options,
+    final bool earlyBlock2Negotiation = false,
+    final int maxRetransmit = 0,
+    final CoapMulticastResponseHandler? onMulticastResponse,
+  }) {
+    final request = CoapRequest.newFetch(confirmable: confirmable);
+    _build(
+      request,
+      path,
+      accept,
+      options,
+      earlyBlock2Negotiation,
+      maxRetransmit,
+    );
+    return send(request, onMulticastResponse: onMulticastResponse);
+  }
+
+  /// Sends a PATCH request.
+  ///
+  /// See [RFC 8132, section 3].
+  ///
+  /// [RFC 8132, section 3]: https://www.rfc-editor.org/rfc/rfc8132.html#section-3
+  Future<CoapResponse> patch(
+    final String path, {
+    required final String payload,
+    final CoapMediaType? format,
+    final CoapMediaType? accept,
+    final bool confirmable = true,
+    final List<Uint8Buffer>? etags,
+    final MatchEtags matchEtags = MatchEtags.onMatch,
+    final List<CoapOption>? options,
+    final bool earlyBlock2Negotiation = false,
+    final int maxRetransmit = 0,
+    final CoapMulticastResponseHandler? onMulticastResponse,
+  }) {
+    final request = CoapRequest.newPatch(confirmable: confirmable)
+      ..setPayloadMedia(payload, format);
+    _build(
+      request,
+      path,
+      accept,
+      options,
+      earlyBlock2Negotiation,
+      maxRetransmit,
+      etags: etags,
+      matchEtags: matchEtags,
+    );
+    return send(request, onMulticastResponse: onMulticastResponse);
+  }
+
+  /// Sends a PATCH request with the specified byte payload.
+  ///
+  /// See [RFC 8132, section 3].
+  ///
+  /// [RFC 8132, section 3]: https://www.rfc-editor.org/rfc/rfc8132.html#section-3
+  Future<CoapResponse> patchBytes(
+    final String path, {
+    required final Uint8Buffer payload,
+    final CoapMediaType? format,
+    final MatchEtags matchEtags = MatchEtags.onMatch,
+    final List<Uint8Buffer>? etags,
+    final CoapMediaType? accept,
+    final bool confirmable = true,
+    final List<CoapOption>? options,
+    final bool earlyBlock2Negotiation = false,
+    final int maxRetransmit = 0,
+    final CoapMulticastResponseHandler? onMulticastResponse,
+  }) {
+    final request = CoapRequest.newPatch(confirmable: confirmable)
+      ..setPayloadMediaRaw(payload, format);
+    _build(
+      request,
+      path,
+      accept,
+      options,
+      earlyBlock2Negotiation,
+      maxRetransmit,
+      etags: etags,
+      matchEtags: matchEtags,
+    );
+    return send(request, onMulticastResponse: onMulticastResponse);
+  }
+
+  /// Sends an iPATCH request.
+  ///
+  /// See [RFC 8132, section 3].
+  ///
+  /// [RFC 8132, section 3]: https://www.rfc-editor.org/rfc/rfc8132.html#section-3
+  Future<CoapResponse> iPatch(
+    final String path, {
+    required final String payload,
+    final CoapMediaType? format,
+    final CoapMediaType? accept,
+    final bool confirmable = true,
+    final List<Uint8Buffer>? etags,
+    final MatchEtags matchEtags = MatchEtags.onMatch,
+    final List<CoapOption>? options,
+    final bool earlyBlock2Negotiation = false,
+    final int maxRetransmit = 0,
+    final CoapMulticastResponseHandler? onMulticastResponse,
+  }) {
+    final request = CoapRequest.newIPatch(confirmable: confirmable)
+      ..setPayloadMedia(payload, format);
+    _build(
+      request,
+      path,
+      accept,
+      options,
+      earlyBlock2Negotiation,
+      maxRetransmit,
+      etags: etags,
+      matchEtags: matchEtags,
+    );
+    return send(request, onMulticastResponse: onMulticastResponse);
+  }
+
+  /// Sends a iPATCH request with the specified byte payload.
+  ///
+  /// See [RFC 8132, section 3].
+  ///
+  /// [RFC 8132, section 3]: https://www.rfc-editor.org/rfc/rfc8132.html#section-3
+  Future<CoapResponse> iPatchBytes(
+    final String path, {
+    required final Uint8Buffer payload,
+    final CoapMediaType? format,
+    final MatchEtags matchEtags = MatchEtags.onMatch,
+    final List<Uint8Buffer>? etags,
+    final CoapMediaType? accept,
+    final bool confirmable = true,
+    final List<CoapOption>? options,
+    final bool earlyBlock2Negotiation = false,
+    final int maxRetransmit = 0,
+    final CoapMulticastResponseHandler? onMulticastResponse,
+  }) {
+    final request = CoapRequest.newIPatch(confirmable: confirmable)
+      ..setPayloadMediaRaw(payload, format);
+    _build(
+      request,
+      path,
+      accept,
+      options,
+      earlyBlock2Negotiation,
+      maxRetransmit,
+      etags: etags,
+      matchEtags: matchEtags,
+    );
+    return send(request, onMulticastResponse: onMulticastResponse);
+  }
+
   /// Observe
   Future<CoapObserveClientRelation> observe(
     final CoapRequest request, {

--- a/lib/src/coap_request.dart
+++ b/lib/src/coap_request.dart
@@ -126,6 +126,6 @@ class CoapRequest extends CoapMessage {
       CoapRequest(CoapCode.patch, confirmable: confirmable);
 
   /// Construct a iPATCH request.
-  factory CoapRequest.newIpatch({final bool confirmable = true}) =>
+  factory CoapRequest.newIPatch({final bool confirmable = true}) =>
       CoapRequest(CoapCode.ipatch, confirmable: confirmable);
 }

--- a/lib/src/coap_request.dart
+++ b/lib/src/coap_request.dart
@@ -117,5 +117,15 @@ class CoapRequest extends CoapMessage {
   factory CoapRequest.newDelete({final bool confirmable = true}) =>
       CoapRequest(CoapCode.delete, confirmable: confirmable);
 
-  // TODO(JKRhb): Add constructors for FETCH, PATCH, and iPATCH
+  /// Construct a FETCH request.
+  factory CoapRequest.newFetch({final bool confirmable = true}) =>
+      CoapRequest(CoapCode.fetch, confirmable: confirmable);
+
+  /// Construct a PATCH request.
+  factory CoapRequest.newPatch({final bool confirmable = true}) =>
+      CoapRequest(CoapCode.patch, confirmable: confirmable);
+
+  /// Construct a iPATCH request.
+  factory CoapRequest.newIpatch({final bool confirmable = true}) =>
+      CoapRequest(CoapCode.ipatch, confirmable: confirmable);
 }


### PR DESCRIPTION
This is a relatively simple PR that adds support for the newly defined `FETCH`, `PATCH`, and `iPATCH` methods to the `CoapClient`  and `CoapRequest` classes. It could be included in the 5.0.0 release but we might as well integrate it in 5.1.0.

CC @JosefWN 