### PR TITLE
refactor: use HashMap for "parsing" numeric Content-Formats

### DIFF
--- a/lib/src/coap_media_type.dart
+++ b/lib/src/coap_media_type.dart
@@ -5,6 +5,7 @@
  * Copyright :  S.Hamblett
  */
 
+import 'dart:collection';
 import 'dart:io';
 import 'package:collection/collection.dart';
 
@@ -275,9 +276,14 @@ enum CoapMediaType {
         parameters: parameters,
       );
 
-  // TODO(JKRhb): Rework to switch statement?
-  static CoapMediaType? fromIntValue(final int value) => CoapMediaType.values
-      .firstWhereOrNull((final element) => element.numericValue == value);
+  static final _registry = HashMap.fromEntries(
+    values.map(
+      (final contentFormat) =>
+          MapEntry(contentFormat.numericValue, contentFormat),
+    ),
+  );
+
+  static CoapMediaType? fromIntValue(final int value) => _registry[value];
 
   /// Parses a string-based contentType [value] and [encoding] and returns
   /// a [CoapMediaType], if a match has been found.

--- a/lib/src/coap_media_type.dart
+++ b/lib/src/coap_media_type.dart
@@ -219,7 +219,7 @@ enum CoapMediaType {
   ),
 
   /// application/td+json
-  applicationTdJson(432, 'application', 'application/td+json'),
+  applicationTdJson(432, 'application', 'td+json'),
 
   /// application/voucher-cose+cbor
   applicationVoucerCoseCbor(836, 'application', 'voucher-cose+cbor'),


### PR DESCRIPTION
This PR refactors the creation of `CoapMediaType`s from numeric values by using a `HashMap` as a registry instead of iterating over all values. This should somewhat increase the performance, as `CoapMediaType`s can now be determined with constant instead of linear complexity.