### PR TITLE
feat!: introcuce `_sendWithStreamResponse` and `sendMulticast` methods, refactor send and observe implementations

### DIFF
--- a/example/get_observe_async.dart
+++ b/example/get_observe_async.dart
@@ -28,8 +28,8 @@ FutureOr<void> main() async {
   try {
     print('Observing /obs on ${uri.host}');
     final obs = await client.observe(reqObs);
-    obs.stream.listen((final e) {
-      print('/obs response: ${e.resp.payloadString}');
+    obs.listen((final e) {
+      print('/obs response: ${e.payloadString}');
     });
 
     final reqObsNon = CoapRequest(CoapCode.get, confirmable: false)
@@ -37,8 +37,8 @@ FutureOr<void> main() async {
 
     print('Observing /obs-non on ${uri.host}');
     final obsNon = await client.observe(reqObsNon);
-    obsNon.stream.listen((final e) {
-      print('/obs-non response: ${e.resp.payloadString}');
+    obsNon.listen((final e) {
+      print('/obs-non response: ${e.payloadString}');
     });
 
     final futures = <Future<void>>[];

--- a/example/get_resource_multicast.dart
+++ b/example/get_resource_multicast.dart
@@ -1,0 +1,38 @@
+// ignore_for_file: avoid_print
+
+/*
+ * Package : Coap
+ * Author : S. Hamblett <steve.hamblett@linux.com>
+ * Date   : 06/06/2018
+ * Copyright :  S.Hamblett
+ *
+ * Example for iterating over responses using sendMulticast().
+ *
+ * For this to work, you need at least one CoAP node reachable under the
+ * link-local IPv6 "All Nodes" multicast address (ff02::1), exposing its
+ * resources using `/.well-known/core`.
+ */
+
+import 'dart:async';
+import 'package:coap/coap.dart';
+
+FutureOr<void> main() async {
+  final uri = Uri(
+    scheme: 'coap',
+    host: CoapDefinedAddress.allNodesIPV6,
+  );
+  final client = CoapClient(uri);
+
+  try {
+    final request = CoapRequest.newGet()..uriPath = '/.well-known/core';
+
+    await for (final response in client.sendMulticast(request)) {
+      print(response.payloadString);
+      break;
+    }
+  } on Exception catch (e) {
+    print('CoAP encountered an exception: $e');
+  }
+
+  client.close();
+}

--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -513,7 +513,7 @@ class CoapClient {
               response.token!.equals(request.token!) ||
               (response.multicastToken?.equals(request.token!) ?? false),
         )
-        .takeWhile((final _) => !request.isTimedOut && !request.isCancelled);
+        .takeWhile((final _) => request.isActive);
 
     _endpoint!.sendEpRequest(request);
 
@@ -659,7 +659,7 @@ class CoapClient {
         .where((final e) => e.msg.id == req.id)
         .take(1)
         .listen((final e) {
-      if (req.isTimedOut || req.isCancelled) {
+      if (!req.isActive) {
         completer.complete(null);
       } else {
         e.msg.timestamp = DateTime.now();

--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -520,6 +520,16 @@ class CoapClient {
     yield* stream;
   }
 
+  /// Sends a [request] and returns a [Stream] of [CoapResponse]s.
+  ///
+  /// This method is especially useful for multicast scenarios, allowing the
+  /// caller to asynchronously iterate over incoming responses. However, you
+  /// can also use it for obtaining the response to a unicast requests as a
+  ///[Stream].
+  Stream<CoapResponse> sendMulticast(final CoapRequest request) async* {
+    yield* _sendWithStreamResponse(request);
+  }
+
   /// Cancel ongoing observable request
   Future<void> cancelObserveProactive(
     final CoapObserveClientRelation relation,

--- a/lib/src/coap_message.dart
+++ b/lib/src/coap_message.dart
@@ -219,6 +219,11 @@ abstract class CoapMessage {
     timedOutHook?.call();
   }
 
+  /// Returns `true` if this [CoapMessage] has neither timed out nor has been
+  /// canceled.
+  // TODO(JKRhb): Should rejections be included here as well?
+  bool get isActive => !isTimedOut && !isCancelled;
+
   /// Retransmit hook function
   HookFunction? retransmittingHook;
 

--- a/lib/src/coap_observe_client_relation.dart
+++ b/lib/src/coap_observe_client_relation.dart
@@ -5,27 +5,57 @@
  * Copyright :  S.Hamblett
  */
 
+import 'dart:async';
+
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 
 import 'coap_request.dart';
-import 'event/coap_event_bus.dart';
+import 'coap_response.dart';
 
 /// Represents a CoAP observe relation between a CoAP client and a
 /// resource on a server.
 /// Provides a simple API to check whether a relation has successfully
 /// established and to cancel or refresh the relation.
-class CoapObserveClientRelation {
+class CoapObserveClientRelation extends Stream<CoapResponse> {
   /// Construction
-  CoapObserveClientRelation(this._request);
+  CoapObserveClientRelation(this._request, this._responseStream);
 
-  /// Response stream
-  Stream<CoapRespondEvent> get stream => _request.eventBus!
-      .on<CoapRespondEvent>()
-      .where((final e) => e.resp.token!.equals(_request.token!))
-      .takeWhile((final _) => !_request.isTimedOut && !_request.isCancelled);
+  @override
+  StreamSubscription<CoapResponse> listen(
+    final void Function(CoapResponse event)? onData, {
+    final Function? onError,
+    final void Function()? onDone,
+    final bool? cancelOnError,
+  }) =>
+      _filteredStream.listen(
+        onData,
+        onError: onError,
+        onDone: onDone,
+        cancelOnError: cancelOnError,
+      );
 
   final CoapRequest _request;
+
+  final Stream<CoapResponse> _responseStream;
+
+  Stream<CoapResponse> get _filteredStream => _responseStream
+      .takeWhile(_requestIsActive);
+      .where(_responseTokenIsMatched)
+
+  bool _responseTokenIsMatched(final CoapResponse response) {
+    final requestToken = _request.token;
+    final responseToken = response.token;
+
+    if (requestToken == null || responseToken == null) {
+      return false;
+    }
+
+    return requestToken.equals(responseToken);
+  }
+
+  bool _requestIsActive(final CoapResponse _) =>
+      !_request.isTimedOut && !_request.isCancelled;
 
   bool _cancelled = false;
 

--- a/lib/src/coap_observe_client_relation.dart
+++ b/lib/src/coap_observe_client_relation.dart
@@ -40,8 +40,8 @@ class CoapObserveClientRelation extends Stream<CoapResponse> {
   final Stream<CoapResponse> _responseStream;
 
   Stream<CoapResponse> get _filteredStream => _responseStream
-      .takeWhile(_requestIsActive);
       .where(_responseTokenIsMatched)
+      .takeWhile((final _) => _request.isActive);
 
   bool _responseTokenIsMatched(final CoapResponse response) {
     final requestToken = _request.token;
@@ -53,9 +53,6 @@ class CoapObserveClientRelation extends Stream<CoapResponse> {
 
     return requestToken.equals(responseToken);
   }
-
-  bool _requestIsActive(final CoapResponse _) =>
-      !_request.isTimedOut && !_request.isCancelled;
 
   bool _cancelled = false;
 

--- a/lib/src/stack/coap_reliability_layer.dart
+++ b/lib/src/stack/coap_reliability_layer.dart
@@ -61,9 +61,8 @@ class CoapTransmissionContext {
     // Do not retransmit a message if it has been acknowledged,
     // rejected, canceled or already been retransmitted for the maximum
     // number of times.
-    if (!_message.isCancelled &&
-        !_message.isRejected &&
-        !_message.isTimedOut &&
+    if (!_message.isRejected &&
+        _message.isActive &&
         failedTransmissionCount <=
             (_message.maxRetransmit != 0
                 ? _message.maxRetransmit


### PR DESCRIPTION
Thinking about a more elegant solution for performing multicast requests, I came up with introducing a special `sendStream` method on the client, which does not return a single `Future<CoapResponse>` but a `Stream` of responses library users can decide to listen to.

With this new API present, I realized that other aspects of the client could be refactored, too, making certain aspects of the client a bit more elegant. This includes the `CoapObserveClientRelation` class, which I refactored into an extension of the `Stream` class, increasing its usability.

All in all, I am quite happy with this new approach which should not only improve the usability for multicast scenarios but of the library as a whole.