### PR TITLE
Fix timeout/max retransmission handling

### DIFF
--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -505,8 +505,8 @@ class CoapClient {
     await _prepare(request);
 
     final stream = _eventBus
-        .on<CoapRespondEvent>()
-        .map((final event) => event.resp)
+        .on<CoapCompletionEvent>()
+        .transform<CoapResponse>(_filterEventStream(request))
         .where(
           (final response) =>
               response.token!.equals(request.token!) ||
@@ -644,17 +644,13 @@ class CoapClient {
     final Stream<CoapResponse> responseStream,
   ) {
     final completer = Completer<CoapResponse>();
-    responseStream.take(1).listen((final response) {
-      if (request.isTimedOut) {
-        completer
-            .completeError(CoapRequestTimeoutException(request.retransmits));
-      } else if (request.isCancelled) {
-        completer.completeError(CoapRequestCancellationException());
-      } else {
+    responseStream.take(1).listen(
+      (final response) {
         response.timestamp = DateTime.now();
         completer.complete(response);
-      }
-    });
+      },
+      onError: completer.completeError,
+    );
     return completer.future;
   }
 
@@ -677,3 +673,34 @@ class CoapClient {
     return completer.future;
   }
 }
+
+StreamTransformer<CoapCompletionEvent, CoapResponse> _filterEventStream(
+  final CoapRequest request,
+) =>
+    StreamTransformer<CoapCompletionEvent, CoapResponse>(
+        (final input, final cancelOnError) {
+      final controller = StreamController<CoapResponse>();
+
+      controller.onListen = () {
+        final subscription = input.listen(
+          (final event) async {
+            if (event is CoapRespondEvent) {
+              controller.add(event.resp);
+            } else if (event is CoapTimedOutEvent) {
+              controller.addError(
+                CoapRequestTimeoutException(request.maxRetransmit),
+              );
+            }
+          },
+          onDone: controller.close,
+          onError: controller.addError,
+          cancelOnError: cancelOnError,
+        );
+        controller
+          ..onPause = subscription.pause
+          ..onResume = subscription.resume
+          ..onCancel = subscription.cancel;
+      };
+
+      return controller.stream.listen(null);
+    });

--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -507,11 +507,7 @@ class CoapClient {
     final stream = _eventBus
         .on<CoapCompletionEvent>()
         .transform<CoapResponse>(_filterEventStream(request))
-        .where(
-          (final response) =>
-              response.token!.equals(request.token!) ||
-              (response.multicastToken?.equals(request.token!) ?? false),
-        )
+        .where((final response) => _matchResponse(response, request))
         .takeWhile((final _) => request.isActive);
 
     _endpoint!.sendEpRequest(request);
@@ -673,6 +669,10 @@ class CoapClient {
     return completer.future;
   }
 }
+
+bool _matchResponse(final CoapResponse response, final CoapRequest request) =>
+    response.token!.equals(request.token!) ||
+    (response.multicastToken?.equals(request.token!) ?? false);
 
 StreamTransformer<CoapCompletionEvent, CoapResponse> _filterEventStream(
   final CoapRequest request,

--- a/lib/src/event/coap_event_bus.dart
+++ b/lib/src/event/coap_event_bus.dart
@@ -15,6 +15,9 @@ import '../coap_request.dart';
 import '../coap_response.dart';
 import '../net/exchange.dart';
 
+/// Interface for events that yield a [CoapResponse] or an [Exception].
+abstract class CoapCompletionEvent {}
+
 abstract class CoapMessageEvent {
   CoapMessageEvent(this.msg);
 
@@ -73,7 +76,8 @@ class CoapRetransmitEvent extends CoapMessageEvent {
 }
 
 /// Timed out event
-class CoapTimedOutEvent extends CoapMessageEvent {
+class CoapTimedOutEvent extends CoapMessageEvent
+    implements CoapCompletionEvent {
   CoapTimedOutEvent(super.msg);
 }
 
@@ -83,7 +87,8 @@ class CoapCancelledEvent extends CoapMessageEvent {
 }
 
 /// Response event
-class CoapRespondEvent extends CoapResponseEvent {
+class CoapRespondEvent extends CoapResponseEvent
+    implements CoapCompletionEvent {
   CoapRespondEvent(super.resp);
 }
 


### PR DESCRIPTION
This PR provides a solution for the bug uncovered by @shamblett in https://github.com/shamblett/coap/issues/132#issuecomment-1288068964. The filtering logic is now moved inside a `StreamTransformer` object, which adds exceptions to the stream on timeout or cancellation. Similar to your suggestion in the issue, the relevant events are pre-filtered using a new `CoapCompletionEvent` interface that is "implemented" by the `CoapResponse`, `CoapRequestTimeoutException`, and `CoapRequestCancellationException` classes. Lastly, the PR applies minor refactoring to the matching of the original request and relevant responses.