### PR TITLE
fix: report correct retransmit count on timeout

### DIFF
--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -690,7 +690,7 @@ StreamTransformer<CoapCompletionEvent, CoapResponse> _filterEventStream(
               controller.add(event.resp);
             } else if (event is CoapTimedOutEvent) {
               controller.addError(
-                CoapRequestTimeoutException(request.maxRetransmit),
+                CoapRequestTimeoutException(request.retransmits),
               );
             }
           },


### PR DESCRIPTION
In the context of #138, I noticed that the `CoapRequestTimeoutException` is currently a bit broken and does not display the correct number of retransmits (instead, it always reports 0 retransmits). This PR provides a simple fix.