### PR TITLE
refactor!: refactor CoapCodes as separate enums

### DIFF
--- a/example/get_observe_async.dart
+++ b/example/get_observe_async.dart
@@ -32,7 +32,7 @@ FutureOr<void> main() async {
       print('/obs response: ${e.payloadString}');
     });
 
-    final reqObsNon = CoapRequest(CoapCode.get, confirmable: false)
+    final reqObsNon = CoapRequest(RequestMethod.get, confirmable: false)
       ..uriPath = 'obs-non';
 
     print('Observing /obs-non on ${uri.host}');

--- a/example/sync_vs_async.dart
+++ b/example/sync_vs_async.dart
@@ -33,7 +33,7 @@ FutureOr<void> main() async {
     for (var i = 0; i < 10; i++) {
       futures.add(
         client.get('test').then((final resp) {
-          if (resp.code != CoapCode.content) {
+          if (resp.responseCode != ResponseCode.content) {
             print('Request failed!');
           }
         }),
@@ -50,7 +50,7 @@ FutureOr<void> main() async {
     print('Sending 10 sync requests...');
     for (var i = 0; i < 10; i++) {
       final resp = await client.get('test');
-      if (resp.code != CoapCode.content) {
+      if (resp.responseCode != ResponseCode.content) {
         print('Request failed!');
       }
     }

--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -125,7 +125,7 @@ class CoapClient {
 
   /// Performs a CoAP ping.
   Future<bool> ping() async {
-    final request = CoapRequest(CoapCode.empty)
+    final request = CoapRequest(RequestMethod.empty)
       ..token = CoapConstants.emptyToken;
     await _prepare(request);
     _endpoint!.sendEpRequest(request);

--- a/lib/src/coap_empty_message.dart
+++ b/lib/src/coap_empty_message.dart
@@ -17,7 +17,8 @@ import 'option/option.dart';
 /// the MessageType ACK or RST.
 class CoapEmptyMessage extends CoapMessage {
   /// Instantiates a new empty message.
-  CoapEmptyMessage(final CoapMessageType type) : super(CoapCode.empty, type);
+  CoapEmptyMessage(final CoapMessageType type)
+      : super(RequestMethod.empty.coapCode, type);
 
   /// Create a new acknowledgment for the specified message.
   /// Returns the acknowledgment.
@@ -43,7 +44,6 @@ class CoapEmptyMessage extends CoapMessage {
         ..destination = message.source;
 
   CoapEmptyMessage.fromParsed({
-    required final CoapCode coapCode,
     required final CoapMessageType type,
     required final int id,
     required final Uint8Buffer token,
@@ -52,7 +52,7 @@ class CoapEmptyMessage extends CoapMessage {
     required final bool hasUnknownCriticalOption,
     required final bool hasFormatError,
   }) : super.fromParsed(
-          coapCode,
+          RequestMethod.empty.coapCode,
           type,
           id: id,
           token: token,

--- a/lib/src/coap_message.dart
+++ b/lib/src/coap_message.dart
@@ -58,13 +58,13 @@ abstract class CoapMessage {
 
   bool hasFormatError = false;
 
-  CoapMessageType? _type;
+  CoapMessageType _type;
 
   @internal
-  set type(final CoapMessageType? type) => _type = type;
+  set type(final CoapMessageType type) => _type = type;
 
   /// The type of this CoAP message.
-  CoapMessageType? get type => _type;
+  CoapMessageType get type => _type;
 
   /// The code of this CoAP message.
   final CoapCode code;

--- a/lib/src/coap_request.dart
+++ b/lib/src/coap_request.dart
@@ -25,18 +25,14 @@ import 'option/option.dart';
 class CoapRequest extends CoapMessage {
   /// Initializes a request message.
   /// Defaults to confirmable
-  CoapRequest(final CoapCode code, {final bool confirmable = true})
+  CoapRequest(this.method, {final bool confirmable = true})
       : super(
-          code,
+          method.coapCode,
           confirmable ? CoapMessageType.con : CoapMessageType.non,
-        ) {
-    if (!code.isRequest && !code.isEmpty) {
-      throw ArgumentError('Expected CoAP method code, got $code');
-    }
-  }
+        );
 
   /// The request method(code)
-  CoapCode get method => code;
+  final RequestMethod method;
 
   @override
   CoapMessageType get type {
@@ -102,34 +98,34 @@ class CoapRequest extends CoapMessage {
 
   /// Construct a GET request.
   factory CoapRequest.newGet({final bool confirmable = true}) =>
-      CoapRequest(CoapCode.get, confirmable: confirmable);
+      CoapRequest(RequestMethod.get, confirmable: confirmable);
 
   /// Construct a POST request.
   factory CoapRequest.newPost({final bool confirmable = true}) =>
-      CoapRequest(CoapCode.post, confirmable: confirmable);
+      CoapRequest(RequestMethod.post, confirmable: confirmable);
 
   /// Construct a PUT request.
   factory CoapRequest.newPut({final bool confirmable = true}) =>
-      CoapRequest(CoapCode.put, confirmable: confirmable);
+      CoapRequest(RequestMethod.put, confirmable: confirmable);
 
   /// Construct a DELETE request.
   factory CoapRequest.newDelete({final bool confirmable = true}) =>
-      CoapRequest(CoapCode.delete, confirmable: confirmable);
+      CoapRequest(RequestMethod.delete, confirmable: confirmable);
 
   /// Construct a FETCH request.
   factory CoapRequest.newFetch({final bool confirmable = true}) =>
-      CoapRequest(CoapCode.fetch, confirmable: confirmable);
+      CoapRequest(RequestMethod.fetch, confirmable: confirmable);
 
   /// Construct a PATCH request.
   factory CoapRequest.newPatch({final bool confirmable = true}) =>
-      CoapRequest(CoapCode.patch, confirmable: confirmable);
+      CoapRequest(RequestMethod.patch, confirmable: confirmable);
 
   /// Construct a iPATCH request.
   factory CoapRequest.newIPatch({final bool confirmable = true}) =>
-      CoapRequest(CoapCode.ipatch, confirmable: confirmable);
+      CoapRequest(RequestMethod.ipatch, confirmable: confirmable);
 
-  CoapRequest.fromParsed({
-    required final CoapCode coapCode,
+  CoapRequest.fromParsed(
+    this.method, {
     required final CoapMessageType type,
     required final int id,
     required final Uint8Buffer token,
@@ -138,7 +134,7 @@ class CoapRequest extends CoapMessage {
     required final bool hasUnknownCriticalOption,
     required final bool hasFormatError,
   }) : super.fromParsed(
-          coapCode,
+          method.coapCode,
           type,
           id: id,
           token: token,

--- a/lib/src/coap_request.dart
+++ b/lib/src/coap_request.dart
@@ -39,7 +39,7 @@ class CoapRequest extends CoapMessage {
   CoapCode get method => code;
 
   @override
-  CoapMessageType? get type {
+  CoapMessageType get type {
     if (super.type == CoapMessageType.con && isMulticast) {
       return CoapMessageType.non;
     }

--- a/lib/src/coap_response.dart
+++ b/lib/src/coap_response.dart
@@ -19,11 +19,10 @@ import 'option/option.dart';
 /// or a separate response with type CON or NON.
 class CoapResponse extends CoapMessage {
   /// Initializes a response message.
-  CoapResponse(super.code, super.type) {
-    if (!code.isResponse) {
-      throw ArgumentError('Expected CoAP response code, got $code');
-    }
-  }
+  CoapResponse(this.responseCode, final CoapMessageType type)
+      : super(responseCode.coapCode, type);
+
+  final ResponseCode responseCode;
 
   /// Status code as a string
   String get statusCodeString => code.toString();
@@ -63,15 +62,15 @@ class CoapResponse extends CoapMessage {
   /// Type and ID are usually set automatically by the ReliabilityLayer>.
   factory CoapResponse.createResponse(
     final CoapRequest request,
-    final CoapCode statusCode,
+    final ResponseCode statusCode,
     final CoapMessageType type,
   ) =>
       CoapResponse(statusCode, type)
         ..destination = request.source
         ..token = request.token;
 
-  CoapResponse.fromParsed({
-    required final CoapCode coapCode,
+  CoapResponse.fromParsed(
+    this.responseCode, {
     required final CoapMessageType type,
     required final int id,
     required final Uint8Buffer token,
@@ -80,7 +79,7 @@ class CoapResponse extends CoapMessage {
     required final bool hasUnknownCriticalOption,
     required final bool hasFormatError,
   }) : super.fromParsed(
-          coapCode,
+          responseCode.coapCode,
           type,
           id: id,
           token: token,

--- a/lib/src/codec/udp/message_decoder.dart
+++ b/lib/src/codec/udp/message_decoder.dart
@@ -119,10 +119,15 @@ CoapMessage? deserializeUdpMessage(final Uint8Buffer data) {
   }
 
   if (code.isRequest) {
+    final method = RequestMethod.fromCoapCode(code);
+    if (method == null) {
+      return null;
+    }
+
     return CoapRequest.fromParsed(
+      method,
       id: id,
       type: type,
-      coapCode: code,
       token: token,
       options: options,
       payload: payload,
@@ -130,10 +135,15 @@ CoapMessage? deserializeUdpMessage(final Uint8Buffer data) {
       hasFormatError: hasFormatError,
     );
   } else if (code.isResponse) {
+    final responseCode = ResponseCode.fromCoapCode(code);
+    if (responseCode == null) {
+      return null;
+    }
+
     return CoapResponse.fromParsed(
+      responseCode,
       id: id,
       type: type,
-      coapCode: code,
       token: token,
       options: options,
       payload: payload,
@@ -144,7 +154,6 @@ CoapMessage? deserializeUdpMessage(final Uint8Buffer data) {
     return CoapEmptyMessage.fromParsed(
       id: id,
       type: type,
-      coapCode: code,
       token: token,
       options: options,
       payload: payload,

--- a/lib/src/codec/udp/message_encoder.dart
+++ b/lib/src/codec/udp/message_encoder.dart
@@ -24,18 +24,11 @@ Uint8Buffer serializeUdpMessage(final CoapMessage message) {
 
   const version = message_format.Version.version1;
   const versionLength = message_format.Version.bitLength;
-  final type = message.type;
-
-  if (type == null) {
-    throw const FormatException(
-      'Message serialization failed due to undefined type.',
-    );
-  }
 
   // Write fixed-size CoAP headers
   writer
     ..write(version.numericValue, versionLength)
-    ..write(type.code, CoapMessageType.bitLength);
+    ..write(message.type.code, CoapMessageType.bitLength);
 
   final token = message.token;
   final tokenLength = _getTokenLength(token);

--- a/lib/src/stack/layers/blockwise.dart
+++ b/lib/src/stack/layers/blockwise.dart
@@ -93,7 +93,7 @@ class BlockwiseLayer extends BaseLayer {
         } else {
           final error = CoapResponse.createResponse(
             request,
-            CoapCode.requestEntityIncomplete,
+            ResponseCode.requestEntityIncomplete,
             CoapMessageType.con,
           )
             ..addOption(
@@ -110,7 +110,7 @@ class BlockwiseLayer extends BaseLayer {
         if (block1.m) {
           final piggybacked = CoapResponse.createResponse(
             request,
-            CoapCode.continues,
+            ResponseCode.continues,
             CoapMessageType.ack,
           )
             ..addOption(Block1Option.fromParts(block1.num, block1.szx, m: true))
@@ -138,7 +138,7 @@ class BlockwiseLayer extends BaseLayer {
         // ERROR, wrong number, Incomplete
         final error = CoapResponse.createResponse(
           request,
-          CoapCode.requestEntityIncomplete,
+          ResponseCode.requestEntityIncomplete,
           CoapMessageType.con,
         )
           ..addOption(
@@ -350,7 +350,7 @@ class BlockwiseLayer extends BaseLayer {
             ..responseBlockStatus = status;
           super.sendRequest(exchange, block);
         } else {
-          final assembled = CoapResponse(response.code, response.type);
+          final assembled = CoapResponse(response.responseCode, response.type);
           _assembleMessage(status, assembled, response);
 
           // Set overall transfer RTT
@@ -382,7 +382,8 @@ class BlockwiseLayer extends BaseLayer {
   }
 
   bool _requiresBlockwise(final CoapRequest request) {
-    if (request.method == CoapCode.put || request.method == CoapCode.post) {
+    if (request.method == RequestMethod.put ||
+        request.method == RequestMethod.post) {
       return request.payloadSize > _maxMessageSize;
     }
     return false;
@@ -496,7 +497,7 @@ class BlockwiseLayer extends BaseLayer {
       // A blockwise notification transmits the first block only
       block = response;
     } else {
-      block = CoapResponse(response.code, response.type)
+      block = CoapResponse(response.responseCode, response.type)
         ..destination = response.destination
         ..token = response.token
         ..setOptions(response.getAllOptions())

--- a/test/coap_datagram_read_write_test.dart
+++ b/test/coap_datagram_read_write_test.dart
@@ -235,7 +235,7 @@ void main() {
         ..addAll(
           List<int>.generate(tokenLength, ((final index) => index % 256)),
         ));
-      final request = CoapRequest(CoapCode.get)
+      final request = CoapRequest(RequestMethod.get)
         ..id = 5
         ..token = token;
 

--- a/test/coap_message_api_test.dart
+++ b/test/coap_message_api_test.dart
@@ -47,7 +47,7 @@ void main() {
   });
 
   test('Options', () {
-    final message = CoapRequest(CoapCode.get);
+    final message = CoapRequest(RequestMethod.get);
     final opt1 = UriQueryOption.parse(Uint8Buffer());
     expect(
       () => OptionType.fromTypeNumber(9000),

--- a/test/coap_message_encode_decode_test.dart
+++ b/test/coap_message_encode_decode_test.dart
@@ -148,7 +148,7 @@ void main() {
     }
 
     void testMessage(final int testNo) {
-      final CoapMessage msg = CoapRequest(CoapCode.get)
+      final CoapMessage msg = CoapRequest(RequestMethod.get)
         ..id = 12345
         ..payload = (typed.Uint8Buffer()..addAll('payload'.codeUnits));
       final data = serializeUdpMessage(msg);
@@ -166,7 +166,7 @@ void main() {
     }
 
     void testMessageWithOptions(final int testNo) {
-      final CoapMessage msg = CoapRequest(CoapCode.get)
+      final CoapMessage msg = CoapRequest(RequestMethod.get)
         ..id = 12345
         ..payload = (typed.Uint8Buffer()..addAll('payload'.codeUnits))
         ..addOption(
@@ -202,7 +202,7 @@ void main() {
     }
 
     void testMessageWithExtendedOption(final int testNo) {
-      final CoapMessage msg = CoapRequest(CoapCode.get)
+      final CoapMessage msg = CoapRequest(RequestMethod.get)
         ..id = 12345
         ..addOption(ContentFormatOption(0));
       expect(msg.getFirstOption<ContentFormatOption>()!.value, 0);
@@ -231,7 +231,7 @@ void main() {
     }
 
     void testRequestParsing(final int testNo) {
-      final request = CoapRequest(CoapCode.post, confirmable: false)
+      final request = CoapRequest(RequestMethod.post, confirmable: false)
         ..id = 7
         ..token = (typed.Uint8Buffer()..addAll(<int>[11, 82, 165, 77, 3]))
         ..addIfMatchOpaque(typed.Uint8Buffer()..addAll(<int>[34, 239]))
@@ -262,7 +262,7 @@ void main() {
 
     void testResponseParsing(final int testNo) {
       final response = CoapResponse(
-        CoapCode.content,
+        ResponseCode.content,
         CoapMessageType.non,
       )
         ..id = 9


### PR DESCRIPTION
Revisiting the current CoapCode implementation, I got the impression that the APIs for creating new requests and responses could be improved to leave less room for potential errors by introducing separate enums for request methods as well as response and signaling codes. This PR implements this change, creating a `RequestMethod`, a `ResponseCode`, and a `SignalingCode` enum in the process, while turning the `CoapCode` enum into an immutable class that carries the numeric values.

Due to the fact that the empty messages sent during the CoAP ping are currently handled as requests, I could not remove the `empty` value from the `RequestMethod` enum. I added a TODO that this value should be revisited during future reworks of the internal API. However, maybe it could also be left as is.

Since this is unfortunately another breaking API change, we could keep this PR on hold for a while until a 7.0.0 release is due.