### PR TITLE
Address Todos

### DIFF
--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -36,13 +36,20 @@ import 'option/empty_option.dart';
 import 'option/integer_option.dart';
 import 'option/option.dart';
 
-/// The matching scheme to use for supplied ETags on PUT
-// FIXME: The name MatchETags might be a bit misleading, c.f. https://datatracker.ietf.org/doc/html/rfc7252#section-5.10.8.2
+/// The strategy applied for conditional requsts.
+///
+/// Can either specifiy that one of the supplied ETags must match the
+/// target resource [onMatch] or that the target resource must not exist
+/// [onNoneMatch].
+///
+/// See [RFC 7252, section 5.10.8] for more information on conditional requests.
+///
+/// [RFC 7252, section 5.10.8]: https://www.rfc-editor.org/rfc/rfc7252#section-5.10.8
 enum MatchEtags {
-  /// When the ETag matches
+  /// One or more of the supplied ETags must match.
   onMatch,
 
-  /// When none of the ETag matches
+  /// The target resource must not exist.
   onNoneMatch,
 }
 

--- a/lib/src/coap_media_type.dart
+++ b/lib/src/coap_media_type.dart
@@ -332,15 +332,6 @@ enum CoapMediaType {
     );
   }
 
-  /// Indicates if this [CoapMediaType] is printable.
-  // TODO(JKRhb): Are there any uncovered cases?
-  bool get isPrintable =>
-      primaryType == 'text' ||
-      subType.endsWith('xml') ||
-      subType.endsWith('json') ||
-      this == applicationLinkFormat ||
-      this == applicationJavascript;
-
   /// Checks whether the given media type is a type of image.
   /// True iff the media type is a type of image.
   bool get isImage => primaryType == 'image';

--- a/lib/src/coap_message.dart
+++ b/lib/src/coap_message.dart
@@ -103,8 +103,11 @@ abstract class CoapMessage {
     _options.add(option);
   }
 
+  /// Indicates if this message needs to be rejected as specified in
+  /// [RFC 7252, section 5.4.1].
+  ///
+  /// [RFC 7252, section 5.4.1]: https://www.rfc-editor.org/rfc/rfc7252#section-5.4.1
   bool get needsRejection =>
-      // TODO(JKRhb): Revisit conditions for rejection
       (type == CoapMessageType.non && hasUnknownCriticalOption) ||
       hasFormatError ||
       (this is CoapResponse && hasUnknownCriticalOption);

--- a/lib/src/coap_message.dart
+++ b/lib/src/coap_message.dart
@@ -235,8 +235,7 @@ abstract class CoapMessage {
 
   /// Returns `true` if this [CoapMessage] has neither timed out nor has been
   /// canceled.
-  // TODO(JKRhb): Should rejections be included here as well?
-  bool get isActive => !isTimedOut && !isCancelled;
+  bool get isActive => !isTimedOut && !isCancelled && !isRejected;
 
   /// Retransmit hook function
   HookFunction? retransmittingHook;

--- a/lib/src/option/integer_option.dart
+++ b/lib/src/option/integer_option.dart
@@ -187,8 +187,7 @@ class MaxAgeOption extends IntegerOption
       : super.parse(OptionType.maxAge, bytes);
 }
 
-// TODO(JKRhb): Is this really a class U option?
-class HopLimitOption extends IntegerOption implements OscoreOptionClassU {
+class HopLimitOption extends IntegerOption implements OscoreOptionClassE {
   HopLimitOption(final int value) : super(OptionType.hopLimit, value);
 
   HopLimitOption.parse(final Uint8Buffer bytes)
@@ -225,7 +224,6 @@ class NoResponseOption extends IntegerOption {
       : super.parse(OptionType.noResponse, bytes);
 }
 
-// TODO(JKRhb): Is this really a class E option?
 class OcfAcceptContentFormatVersion extends IntegerOption
     implements OscoreOptionClassE {
   OcfAcceptContentFormatVersion(final int value)
@@ -235,7 +233,6 @@ class OcfAcceptContentFormatVersion extends IntegerOption
       : super.parse(OptionType.ocfAcceptContentFormatVersion, bytes);
 }
 
-// TODO(JKRhb): Is this really a class E option?
 class OcfContentFormatVersion extends IntegerOption
     implements OscoreOptionClassE {
   OcfContentFormatVersion(final int value)

--- a/lib/src/option/option.dart
+++ b/lib/src/option/option.dart
@@ -90,7 +90,12 @@ abstract class Option<T> {
 /// Interface for an Oscore class E option (encrypted and integrity protected).
 /// See [RFC 8613, section 4.1.1].
 ///
+/// Also applies to all options that are unknown or or for which OSCORE
+/// processing is not defined (see [RFC 8613, section 4.1]).
+///
 /// [RFC 8613, section 4.1.1]: https://www.rfc-editor.org/rfc/rfc8613.html#section-4.1.1
+/// [RFC 8613, section 4.1]: https://www.rfc-editor.org/rfc/rfc8613.html#section-4.1
+/// https://www.rfc-editor.org/rfc/rfc8613.html#section-4.1
 abstract class OscoreOptionClassE {
   OscoreOptionClassE._();
 }

--- a/lib/src/option/oscore_option.dart
+++ b/lib/src/option/oscore_option.dart
@@ -19,7 +19,6 @@ class OscoreOptionValue {
         kid = _parseKid(byteValue),
         kidContext = _parseKidContext(byteValue);
 
-  // TODO(JKRhb): Maybe this can be done more elegantly
   static Uint8List _encodeInteger(final int integer) => Uint8List.fromList(
         Uint8List.sublistView(Uint64List.fromList([integer]))
             .take((integer / 8).ceil())

--- a/test/coap_base_class_test.dart
+++ b/test/coap_base_class_test.dart
@@ -12,7 +12,6 @@ void main() {
     test('Properties', () {
       const type = CoapMediaType.applicationJson;
       expect(type.mimeType, 'application/json');
-      expect(type.isPrintable, true);
       expect(type.isImage, false);
 
       const unknownType = 200;


### PR DESCRIPTION
This PR addresses some of the TODOs mentioned in #140 and a couple of minor linting issues.

As part of this PR, the `isPrintable` method is removed from the `CoapMediaType` enum as it did not fulfill a real purpose IMHO.