### PR TITLE
fix: adjust default config values

### DIFF
--- a/lib/src/coap_constants.dart
+++ b/lib/src/coap_constants.dart
@@ -34,7 +34,7 @@ class CoapConstants {
   ///
   /// The initial time (ms) for a CoAP message
   ///
-  static const int ackTimeout = 3000;
+  static const int ackTimeout = 2000;
 
   ///
   /// The initial timeout is set

--- a/lib/src/coap_constants.dart
+++ b/lib/src/coap_constants.dart
@@ -46,7 +46,7 @@ class CoapConstants {
   ///
   /// The max times that a message would be retransmitted
   ///
-  static const int maxRetransmit = 8;
+  static const int maxRetransmit = 4;
 
   ///
   /// Default preferred size used for block-wise transfers


### PR DESCRIPTION
This PR should partly resolve #138, adjusting both `maxRetransmit` and `ackTimeout` to the default values specified in [RFC 7252, section 4.8](https://www.rfc-editor.org/rfc/rfc7252#section-4.8).

There might be further possible adjustments to default config values and their handling that could be made in follow-up PRs, but for now this should deal with the most important issue.