### PR TITLE
feat: override toString() method of MulticastAddress

### DIFF
--- a/example/get_resource_multicast.dart
+++ b/example/get_resource_multicast.dart
@@ -17,10 +17,7 @@ import 'dart:async';
 import 'package:coap/coap.dart';
 
 FutureOr<void> main() async {
-  final uri = Uri(
-    scheme: 'coap',
-    host: MulticastAddress.allNodesIPV6.address,
-  );
+  final uri = Uri.parse('coap://${MulticastAddress.allNodesLinkLocalIPV6}');
   final client = CoapClient(uri);
 
   try {

--- a/lib/src/multicast_address.dart
+++ b/lib/src/multicast_address.dart
@@ -8,6 +8,15 @@
 import 'dart:io';
 
 /// Defines well-known multicast addresses from RFC 7252 and RFC 9176.
+///
+/// This enum's [toString] method returns the [address] field. In the case of
+/// IPv6 addresses, the [address] string gets wrapped in square brackets. This
+/// makes it easier to use the enum values in URI strings, such as the
+/// following:
+///
+/// ```dart
+/// final uri = Uri.parse('coap://${MulticastAddress.allNodesLinkLocalIPV6}');
+/// ```
 enum MulticastAddress {
   // Multicast IPV4
   allRoutersIPV4('224.0.0.2'),
@@ -66,4 +75,13 @@ enum MulticastAddress {
   ///
   /// Returns either [InternetAddressType.IPv4] or [InternetAddressType.IPv6].
   InternetAddressType get addressType => internetAddress.type;
+
+  @override
+  String toString() {
+    if (addressType == InternetAddressType.IPv6) {
+      return '[$address]';
+    }
+
+    return address;
+  }
 }


### PR DESCRIPTION
This PR proposes a slight API improvement for the `MulticastAddress` enum. Overriding the `toString` method, the proposed changes make it a bit more convenient to use the enum values in the context of string interpolation.