### PR TITLE
fix(openssl): clean up network on timeout exception

### DIFF
--- a/lib/src/network/coap_network_openssl.dart
+++ b/lib/src/network/coap_network_openssl.dart
@@ -89,7 +89,12 @@ class CoapNetworkUDPOpenSSL extends CoapNetworkUDP {
     await bind();
     _receive();
 
-    await _dtlsConnection?.connect().timeout(CoapINetwork.initTimeout);
+    try {
+      await _dtlsConnection?.connect().timeout(CoapINetwork.initTimeout);
+    } on TimeoutException {
+      close();
+      rethrow;
+    }
 
     isClosed = false;
   }


### PR DESCRIPTION
In the OpenSSL network, it seems to me that currently the network is not properly cleaned up if the initial connect should time out, causing the CoAP client to hang. This PR adjusts the connect behavior, calling `close` if a timeout should happen and rethrowing the `TimeoutException`. 