### PR TITLE
fix: don't call completer on timeout after reconnect

### DIFF
--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -647,10 +647,21 @@ class CoapClient {
     final completer = Completer<CoapResponse>();
     responseStream.take(1).listen(
       (final response) {
+        if (completer.isCompleted) {
+          return;
+        }
+
         response.timestamp = DateTime.now();
         completer.complete(response);
       },
-      onError: completer.completeError,
+      // ignore: avoid_types_on_closure_parameters
+      onError: (final Object error) {
+        if (completer.isCompleted) {
+          return;
+        }
+
+        completer.completeError(error);
+      },
     );
     return completer.future;
   }


### PR DESCRIPTION
This PR contains the fix from https://github.com/shamblett/coap/issues/153#issuecomment-1396977877.

Potentially resolves #153.

CC @vincent-iQontrol 