### PR TITLE
feat: only skip host and port options if non-default

### DIFF
--- a/lib/src/coap_message.dart
+++ b/lib/src/coap_message.dart
@@ -443,12 +443,18 @@ abstract class CoapMessage {
   set contentFormat(final CoapMediaType? value) => contentType = value;
 
   /// The max-age of this CoAP message.
-  int get maxAge {
+  int? get maxAge {
     final opt = getFirstOption<MaxAgeOption>();
-    return opt?.value ?? CoapConstants.defaultMaxAge;
+    return opt?.value;
   }
 
-  set maxAge(final int value) => setOption(MaxAgeOption(value));
+  set maxAge(final int? value) {
+    if (value == null) {
+      removeOptions<MaxAgeOption>();
+    } else {
+      setOption(MaxAgeOption(value));
+    }
+  }
 
   /// Accept
   CoapMediaType? get accept {

--- a/lib/src/coap_message.dart
+++ b/lib/src/coap_message.dart
@@ -519,9 +519,9 @@ abstract class CoapMessage {
   }
 
   /// Size 1
-  int get size1 {
+  int? get size1 {
     final opt = getFirstOption<Size1Option>();
-    return opt?.value ?? 0;
+    return opt?.value;
   }
 
   set size1(final int? value) {
@@ -535,7 +535,7 @@ abstract class CoapMessage {
   /// Size 2
   int? get size2 {
     final opt = getFirstOption<Size2Option>();
-    return opt?.value ?? 0;
+    return opt?.value;
   }
 
   set size2(final int? value) {

--- a/lib/src/coap_message.dart
+++ b/lib/src/coap_message.dart
@@ -597,43 +597,34 @@ abstract class CoapMessage {
       'Options: ${_optionsToString()},\n'
       'Payload: $payloadString';
 
-  String _optionsToString() {
-    // TODO(JKRhb): Refactor
+  void _writeMessageSpecifcOptions(final StringBuffer stringBuffer) {
     final message = this;
-    Object? uriHost;
-    var uriPort = 0;
-    Object? locationPaths;
-    Object? uriPath;
-    Object? uriQueries;
-    Object? locationQueries;
-
     if (message is CoapRequest) {
-      uriHost = message.uriHost;
-      uriPort = message.uriPort;
-      uriPath = message.uriPath;
-      uriQueries = message.uriQueries;
+      final uriPort = message.uriPort;
+      stringBuffer
+        ..write(_optionString('Uri Host', message.uriHost))
+        ..write(_optionString('Uri Port', uriPort > 0 ? uriPort : null))
+        ..write(_optionString('Uri Paths', message.uriPath))
+        ..write(_optionString('Uri Queries', message.uriQueries));
     } else if (message is CoapResponse) {
-      locationPaths = message.locationPaths;
-      locationQueries = message.locationQueries;
+      stringBuffer
+        ..write(_optionString('Location Paths', message.locationPaths))
+        ..write(_optionString('Location Queries', message.locationQueries));
     }
+  }
 
-    final sb = StringBuffer()
-      ..writeln('[')
+  String _optionsToString() {
+    final sb = StringBuffer()..writeln('[');
+
+    _writeMessageSpecifcOptions(sb);
+
+    sb
       ..write(_optionString('If-Match', ifMatches))
-      ..write(_optionString('Uri Host', uriHost))
       ..write(_optionString('E-tags', etags))
       ..write(_optionString('If-None Match', ifNoneMatches))
-      ..write(_optionString('Uri Port', uriPort > 0 ? uriPort : null))
-      ..write(_optionString('Location Paths', locationPaths))
-      ..write(_optionString('Uri Paths', uriPath))
-      ..write(_optionString('Content-Type', contentType.toString()))
+      ..write(_optionString('Content-Type', contentType))
       ..write(_optionString('Max Age', maxAge))
-      ..write(_optionString('Uri Queries', uriQueries));
-    if (accept != null) {
-      sb.write(_optionString('Accept', accept.toString()));
-    }
-    sb
-      ..write(_optionString('Location Queries', locationQueries))
+      ..write(_optionString('Accept', accept))
       ..write(_optionString('Proxy Uri', proxyUri))
       ..write(_optionString('Proxy Scheme', proxyScheme))
       ..write(_optionString('Block 1', block1))

--- a/lib/src/coap_request.dart
+++ b/lib/src/coap_request.dart
@@ -15,7 +15,9 @@ import 'coap_constants.dart';
 import 'coap_message.dart';
 import 'coap_message_type.dart';
 import 'net/endpoint.dart';
+import 'option/integer_option.dart';
 import 'option/option.dart';
+import 'option/string_option.dart';
 
 /// This class describes the functionality of a CoAP Request as
 /// a subclass of a CoAP Message. It provides:
@@ -46,21 +48,51 @@ class CoapRequest extends CoapMessage {
   /// Indicates whether this request is a multicast request or not.
   bool get isMulticast => destination?.isMulticast ?? false;
 
-  Uri? _uri;
+  String? scheme = 'coap';
 
-  /// The URI of this CoAP message.
-  Uri get uri => _uri ??= Uri(
-        scheme: CoapConstants.uriScheme,
-        host: uriHost,
-        port: uriPort,
-        path: uriPath,
-        query: uriQuery,
-      );
+  /// Specifies the target resource of a request to a CoAP origin server.
+  ///
+  /// Composed from the Uri-Host, Uri-Port, Uri-Path, and Uri-Query Options.
+  ///
+  /// See [RFC 7252, Section 5.10.1] for more information.
+  ///
+  /// [RFC 7252, Section 5.10.1]: https://www.rfc-editor.org/rfc/rfc7252#section-5.10.1
+  Uri get uri {
+    final host = getFirstOption<UriHostOption>()?.value ?? destination?.address;
+    final path = getOptions<UriPathOption>()
+        .map((final option) => option.pathSegment)
+        .join();
+    final queryParameters = Map.fromEntries(
+      getOptions<UriQueryOption>().map((final option) => option.queryParameter),
+    );
+
+    final optionPort = getFirstOption<UriPortOption>()?.value;
+
+    final int? port;
+    if (!(optionPort == CoapConstants.defaultPort &&
+            scheme == CoapConstants.uriScheme) &&
+        !(optionPort == CoapConstants.defaultSecurePort &&
+            scheme == CoapConstants.secureUriScheme)) {
+      port = optionPort;
+    } else {
+      port = null;
+    }
+
+    return Uri(
+      scheme: scheme,
+      host: host,
+      port: port,
+      path: path.isNotEmpty ? path : '/',
+      queryParameters: queryParameters.isNotEmpty ? queryParameters : null,
+    );
+  }
 
   @internal
   set uri(final Uri value) {
     final host = value.host;
     var port = value.port;
+    final query = value.query;
+    final path = value.path;
     if (host.isNotEmpty && InternetAddress.tryParse(host) == null) {
       uriHost = host;
     }
@@ -71,14 +103,98 @@ class CoapRequest extends CoapMessage {
         port = CoapConstants.defaultSecurePort;
       }
     }
-    if (uriPort != port) {
-      if (port != CoapConstants.defaultPort) {
-        uriPort = port;
-      } else {
-        uriPort = CoapConstants.defaultPort;
-      }
+    uriPort = port;
+    if (path.isNotEmpty) {
+      uriPath = path;
     }
-    _uri = value;
+    if (query.isNotEmpty) {
+      uriQuery = value.query;
+    }
+    scheme = value.scheme;
+  }
+
+  /// Uri's
+  String get uriHost => uri.host;
+
+  @internal
+  set uriHost(final String value) {
+    setOption(UriHostOption(value));
+  }
+
+  /// URI path
+  String get uriPath => uri.path;
+
+  /// Sets a number of Uri path options from a string
+  set uriPath(final String fullPath) {
+    clearUriPath();
+
+    var trimmedPath = fullPath;
+
+    if (fullPath.startsWith('/')) {
+      trimmedPath = fullPath.substring(1);
+    }
+
+    if (trimmedPath.isEmpty) {
+      return;
+    }
+
+    trimmedPath.split('/').forEach(addUriPath);
+  }
+
+  /// URI paths
+  List<UriPathOption> get uriPaths => getOptions<UriPathOption>();
+
+  /// Add a URI path
+  void addUriPath(final String path) => addOption(UriPathOption(path));
+
+  /// Remove a URI path
+  void removeUriPath(final String path) {
+    removeOptionWhere(
+      (final element) => element is UriPathOption && element.value == path,
+    );
+  }
+
+  /// Clear URI paths
+  void clearUriPath() => removeOptions<UriPathOption>();
+
+  /// URI query
+  String get uriQuery => uri.query;
+
+  /// Set a URI query
+  set uriQuery(final String fullQuery) {
+    var trimmedQuery = fullQuery;
+    if (trimmedQuery.startsWith('?')) {
+      trimmedQuery = trimmedQuery.substring(1);
+    }
+    clearUriQuery();
+    trimmedQuery.split('&').forEach(addUriQuery);
+  }
+
+  /// URI queries
+  List<UriQueryOption> get uriQueries => getOptions<UriQueryOption>();
+
+  /// Add a URI query
+  void addUriQuery(final String query) => addOption(UriQueryOption(query));
+
+  /// Remove a URI query
+  void removeUriQuery(final String query) {
+    removeOptionWhere(
+      (final element) => element is UriQueryOption && element.value == query,
+    );
+  }
+
+  /// Clear URI queries
+  void clearUriQuery() => removeOptions<UriQueryOption>();
+
+  /// Uri port
+  int get uriPort => uri.port;
+
+  set uriPort(final int value) {
+    if (value == 0) {
+      removeOptions<UriPortOption>();
+    } else {
+      addOption(UriPortOption(value));
+    }
   }
 
   Endpoint? _endpoint;

--- a/lib/src/option/string_option.dart
+++ b/lib/src/option/string_option.dart
@@ -44,17 +44,24 @@ abstract class QueryOption extends StringOption {
   }
 }
 
-class LocationPathOption extends StringOption implements OscoreOptionClassE {
-  LocationPathOption(final String value)
-      : super(OptionType.locationPath, value) {
+abstract class PathOption extends StringOption {
+  PathOption(super.type, super.value) {
     if (value == '..' || value == '.') {
-      throw ArgumentError.value(
-        value,
-        'LocationPathOption'
-        'The value of a Location-Path Option must not be "." or ".."',
+      throw FormatException(
+        'The value of a $name Option must not be "." or ".."',
       );
     }
   }
+
+  PathOption.parse(super.type, Uint8Buffer super.bytes) : super.parse();
+
+  @internal
+  String get pathSegment => "/${value.replaceAll('/', '%2F')}";
+}
+
+class LocationPathOption extends PathOption implements OscoreOptionClassE {
+  LocationPathOption(final String value)
+      : super(OptionType.locationPath, value);
 
   LocationPathOption.parse(final Uint8Buffer bytes)
       : super.parse(OptionType.locationPath, bytes);
@@ -67,16 +74,8 @@ class UriHostOption extends StringOption implements OscoreOptionClassU {
       : super.parse(OptionType.uriHost, bytes);
 }
 
-class UriPathOption extends StringOption implements OscoreOptionClassE {
-  UriPathOption(final String value) : super(OptionType.uriPath, value) {
-    if (value == '.' || value == '..') {
-      throw ArgumentError.value(
-        value,
-        'UriPathOption',
-        'The value of a Uri-Path Option must not be "." or ".."',
-      );
-    }
-  }
+class UriPathOption extends PathOption implements OscoreOptionClassE {
+  UriPathOption(final String value) : super(OptionType.uriPath, value);
 
   UriPathOption.parse(final Uint8Buffer bytes)
       : super.parse(OptionType.uriPath, bytes);

--- a/lib/src/option/string_option.dart
+++ b/lib/src/option/string_option.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:meta/meta.dart';
 import 'package:typed_data/typed_data.dart';
 
 import 'coap_option_type.dart';
@@ -26,6 +27,21 @@ abstract class StringOption extends Option<String> {
 
   @override
   String get valueString => value;
+}
+
+abstract class QueryOption extends StringOption {
+  QueryOption(super.type, super.value);
+
+  QueryOption.parse(super.type, Uint8Buffer super.bytes) : super.parse();
+
+  @internal
+  MapEntry<String, String?> get queryParameter {
+    final parameter = this.value.split('=');
+    final key = parameter[0];
+    final value = parameter.length > 1 ? parameter.sublist(1).join('=') : null;
+
+    return MapEntry(key, value);
+  }
 }
 
 class LocationPathOption extends StringOption implements OscoreOptionClassE {
@@ -66,14 +82,14 @@ class UriPathOption extends StringOption implements OscoreOptionClassE {
       : super.parse(OptionType.uriPath, bytes);
 }
 
-class UriQueryOption extends StringOption implements OscoreOptionClassE {
+class UriQueryOption extends QueryOption implements OscoreOptionClassE {
   UriQueryOption(final String value) : super(OptionType.uriQuery, value);
 
   UriQueryOption.parse(final Uint8Buffer bytes)
       : super.parse(OptionType.uriQuery, bytes);
 }
 
-class LocationQueryOption extends StringOption implements OscoreOptionClassE {
+class LocationQueryOption extends QueryOption implements OscoreOptionClassE {
   LocationQueryOption(final String value)
       : super(OptionType.locationQuery, value);
 

--- a/lib/src/option/string_option.dart
+++ b/lib/src/option/string_option.dart
@@ -7,7 +7,7 @@ import 'option.dart';
 
 abstract class StringOption extends Option<String> {
   StringOption(this.type, final String value)
-      : byteValue = Uint8Buffer()..addAll(value.codeUnits);
+      : byteValue = Uint8Buffer()..addAll(utf8.encode(value));
 
   StringOption.parse(this.type, final Uint8Buffer? bytes)
       : byteValue = Uint8Buffer()..addAll(bytes ?? []);

--- a/lib/src/stack/layers/observe.dart
+++ b/lib/src/stack/layers/observe.dart
@@ -8,6 +8,7 @@
 import 'dart:async';
 
 import '../../coap_config.dart';
+import '../../coap_constants.dart';
 import '../../coap_empty_message.dart';
 import '../../coap_message_type.dart';
 import '../../coap_request.dart';
@@ -194,7 +195,8 @@ class ObserveLayer extends BaseLayer {
     final CoapResponse response,
     final void Function(CoapRequest) reregister,
   ) {
-    final timeout = response.maxAge * 1000 + _backoff;
+    final timeout =
+        (response.maxAge ?? CoapConstants.defaultMaxAge) * 1000 + _backoff;
     exchange
         .getOrAdd<_ReregistrationContext>(
           reregistrationContextKey,

--- a/test/coap_message_api_test.dart
+++ b/test/coap_message_api_test.dart
@@ -328,8 +328,8 @@ void main() {
       ..addLocationPath('');
     expect(message.locationPaths.length, 1);
     expect(message.locationPath, '');
-    expect(() => message.locationPath = '..', throwsArgumentError);
-    expect(() => message.locationPath = '.', throwsArgumentError);
+    expect(() => message.locationPath = '..', throwsFormatException);
+    expect(() => message.locationPath = '.', throwsFormatException);
     message.addLocationPath('multiple/are/allowed');
     expect(message.locationPaths.length, 1);
     message.addLocationPath('double-slash//');

--- a/test/coap_message_encode_decode_test.dart
+++ b/test/coap_message_encode_decode_test.dart
@@ -288,7 +288,7 @@ void main() {
       expect(
         leq.equals(
           response.locationPaths.toList(),
-          message.locationPaths.toList(),
+          (message as CoapResponse).locationPaths.toList(),
         ),
         isTrue,
       );


### PR DESCRIPTION
Reading through the RFC, I noticed that the skipping of the Uri-Host and Uri-Port options is not necessary if their values are not the default. Including them as proposed in this PR makes it easier to determine where a request was sent to, as illustrated in the following Wireshark screenshot:

![grafik](https://user-images.githubusercontent.com/12641361/213866473-86b34568-44fc-4261-a461-4df257c45fa1.png)



(This PR depends on #157 and should only be merged afterwards.)