### PR TITLE
feat!: set URI for each request instead of client

### DIFF
--- a/example/cancel_request.dart
+++ b/example/cancel_request.dart
@@ -16,14 +16,14 @@ import 'config/coap_config.dart';
 FutureOr<void> main() async {
   final conf = CoapConfig();
   final uri = Uri(scheme: 'coap', host: 'coap.me', port: conf.defaultPort);
-  final client = CoapClient(uri, config: conf);
+  final client = CoapClient(config: conf);
 
-  final cancelThisReq = CoapRequest.newGet()..uriPath = 'doesNotExist';
+  final cancelThisReq = CoapRequest.newGet(uri.replace(path: 'doesNotExist'));
 
   try {
     // Ensure this request is not also cancelled
     print('Sending async get /hello to ${uri.host}');
-    final helloRespFuture = client.get('hello');
+    final helloRespFuture = client.get(uri.replace(path: 'hello'));
 
     print('Sending async get /doesNotExist to ${uri.host}');
     final ignoreThisFuture = client.send(cancelThisReq);
@@ -44,5 +44,5 @@ FutureOr<void> main() async {
     print('CoAP encountered an exception: $e');
   }
 
-  client.close();
+  await client.close();
 }

--- a/example/delete_resource.dart
+++ b/example/delete_resource.dart
@@ -19,17 +19,18 @@ FutureOr<void> main() async {
     scheme: 'coap',
     host: 'californium.eclipseprojects.io',
     port: conf.defaultPort,
+    path: 'test',
   );
-  final client = CoapClient(uri, config: conf);
+  final client = CoapClient(config: conf);
 
   try {
     print('Sending delete /test to ${uri.host}');
-    final response = await client.delete('test');
+    final response = await client.delete(uri);
 
     print('/test response status: ${response.statusCodeString}');
   } on Exception catch (e) {
     print('CoAP encountered an exception: $e');
   }
 
-  client.close();
+  await client.close();
 }

--- a/example/discover_resources.dart
+++ b/example/discover_resources.dart
@@ -15,12 +15,17 @@ import 'config/coap_config.dart';
 
 FutureOr<void> main() async {
   final conf = CoapConfig();
-  final uri = Uri(scheme: 'coap', host: 'coap.me', port: conf.defaultPort);
-  final client = CoapClient(uri, config: conf);
+  final uri = Uri(
+    scheme: 'coap',
+    host: 'coap.me',
+    port: conf.defaultPort,
+    path: '.well-known/core',
+  );
+  final client = CoapClient(config: conf);
 
   try {
     print('Sending get /discover/.well-known/core to ${uri.host}');
-    final links = await client.discover();
+    final links = await client.discover(uri);
 
     print('Discovered resources:');
     links?.forEach(print);
@@ -28,5 +33,5 @@ FutureOr<void> main() async {
     print('CoAP encountered an exception: $e');
   }
 
-  client.close();
+  await client.close();
 }

--- a/example/get_blockwise.dart
+++ b/example/get_blockwise.dart
@@ -15,17 +15,22 @@ import 'config/coap_config.dart';
 
 FutureOr<void> main() async {
   final conf = CoapConfig();
-  final uri = Uri(scheme: 'coap', host: 'coap.me', port: conf.defaultPort);
-  final client = CoapClient(uri, config: conf);
+  final uri = Uri(
+    scheme: 'coap',
+    host: 'coap.me',
+    port: conf.defaultPort,
+    path: 'large',
+  );
+  final client = CoapClient(config: conf);
 
   try {
     print('Sending get /large to ${uri.host}');
-    final response = await client.get('large');
+    final response = await client.get(uri);
 
     print('/large response: ${response.payloadString}');
   } on Exception catch (e) {
     print('CoAP encountered an exception: $e');
   }
 
-  client.close();
+  await client.close();
 }

--- a/example/get_max_retransmit.dart
+++ b/example/get_max_retransmit.dart
@@ -15,12 +15,17 @@ import './config/coap_config.dart';
 
 FutureOr<void> main() async {
   final conf = CoapConfig();
-  final uri = Uri(scheme: 'coap', host: 'google.com', port: conf.defaultPort);
-  final client = CoapClient(uri, config: conf);
+  final uri = Uri(
+    scheme: 'coap',
+    host: 'google.com',
+    port: conf.defaultPort,
+    path: 'doesNotExist',
+  );
+  final client = CoapClient(config: conf);
 
   print('maxRetransmit config: ${conf.maxRetransmit}');
 
-  final request = CoapRequest.newGet()..uriPath = 'doesNotExist';
+  final request = CoapRequest.newGet(uri);
   print('maxRetransmit request: ${request.maxRetransmit} (0=config default)');
 
   try {
@@ -43,5 +48,5 @@ FutureOr<void> main() async {
     print('CoAP encountered an exception: $e');
   }
 
-  client.close();
+  await client.close();
 }

--- a/example/get_observe_async.dart
+++ b/example/get_observe_async.dart
@@ -19,11 +19,12 @@ FutureOr<void> main() async {
     scheme: 'coap',
     host: 'californium.eclipseprojects.io',
     port: conf.defaultPort,
+    path: 'obs',
   );
-  final client = CoapClient(uri, config: conf);
+  final client = CoapClient(config: conf);
 
   // Create the request for the get request
-  final reqObs = CoapRequest.newGet()..uriPath = 'obs';
+  final reqObs = CoapRequest.newGet(uri);
 
   try {
     print('Observing /obs on ${uri.host}');
@@ -32,8 +33,11 @@ FutureOr<void> main() async {
       print('/obs response: ${e.payloadString}');
     });
 
-    final reqObsNon = CoapRequest(RequestMethod.get, confirmable: false)
-      ..uriPath = 'obs-non';
+    final reqObsNon = CoapRequest(
+      RequestMethod.get,
+      uri.replace(path: 'obs-non'),
+      confirmable: false,
+    );
 
     print('Observing /obs-non on ${uri.host}');
     final obsNon = await client.observe(reqObsNon);
@@ -44,7 +48,7 @@ FutureOr<void> main() async {
     final futures = <Future<void>>[];
     print('Sending get /large to ${uri.host}');
     futures.add(
-      client.get('large').then(
+      client.get(uri.replace(path: 'large')).then(
             (final resp) => print('/large response: ${resp.payloadString}'),
           ),
     );
@@ -52,13 +56,13 @@ FutureOr<void> main() async {
     print('Sending get /test to ${uri.host}');
     futures.add(
       client
-          .get('test')
+          .get(uri.replace(path: 'test'))
           .then((final resp) => print('/test response: ${resp.payloadString}')),
     );
 
     print('Sending get /separate to ${uri.host}');
     futures.add(
-      client.get('separate').then(
+      client.get(uri.replace(path: 'separate')).then(
             (final resp) => print('/separate response: ${resp.payloadString}'),
           ),
     );
@@ -76,5 +80,5 @@ FutureOr<void> main() async {
     print('CoAP encountered an exception: $e');
   }
 
-  client.close();
+  await client.close();
 }

--- a/example/get_resource.dart
+++ b/example/get_resource.dart
@@ -15,25 +15,26 @@ import 'config/coap_config.dart';
 
 FutureOr<void> main() async {
   final conf = CoapConfig();
-  final uri = Uri(scheme: 'coap', host: 'coap.me', port: conf.defaultPort);
-  final client = CoapClient(uri, config: conf);
+  final client = CoapClient(config: conf);
 
   try {
-    print('Sending get /test to ${uri.host}');
-    var response = await client.get('test');
+    // print('Sending get /test to ${uri.host}');
+    var response = await client.get(Uri.parse('coap://coap.me/test'));
     print('/test response: ${response.payloadString}');
 
-    print('Sending get /multi-format (text) to ${uri.host}');
-    response = await client.get('multi-format');
+    // print('Sending get /multi-format (text) to ${uri.host}');
+    response = await client.get(Uri.parse('coap://coap.me/multi-format'));
     print('/multi-format (text) response: ${response.payloadString}');
 
-    print('Sending get /multi-format (xml) to ${uri.host}');
-    response =
-        await client.get('multi-format', accept: CoapMediaType.applicationXml);
+    // print('Sending get /multi-format (xml) to ${uri.host}');
+    response = await client.get(
+      Uri.parse('coap://coap.me/multi-format'),
+      accept: CoapMediaType.applicationXml,
+    );
     print('/multi-format (xml) response: ${response.payloadString}');
   } on Exception catch (e) {
     print('CoAP encountered an exception: $e');
   }
 
-  client.close();
+  await client.close();
 }

--- a/example/get_resource_multicast.dart
+++ b/example/get_resource_multicast.dart
@@ -17,11 +17,13 @@ import 'dart:async';
 import 'package:coap/coap.dart';
 
 FutureOr<void> main() async {
-  final uri = Uri.parse('coap://${MulticastAddress.allNodesLinkLocalIPV6}');
-  final client = CoapClient(uri);
+  final uri = Uri.parse(
+    'coap://${MulticastAddress.allNodesLinkLocalIPV6}/.well-known/core',
+  );
+  final client = CoapClient();
 
   try {
-    final request = CoapRequest.newGet()..uriPath = '/.well-known/core';
+    final request = CoapRequest.newGet(uri);
 
     await for (final response in client.sendMulticast(request)) {
       print(response.payloadString);
@@ -31,5 +33,5 @@ FutureOr<void> main() async {
     print('CoAP encountered an exception: $e');
   }
 
-  client.close();
+  await client.close();
 }

--- a/example/get_resource_secure.dart
+++ b/example/get_resource_secure.dart
@@ -25,7 +25,10 @@ final preSharedKey = Uint8List.fromList(utf8.encode('secretPSK'));
 final pskCredentials =
     PskCredentials(identity: identity, preSharedKey: preSharedKey);
 
-PskCredentials pskCredentialsCallback(final Uint8List indentity) =>
+PskCredentials pskCredentialsCallback(
+  final Uint8List indentity,
+  final Uri uri,
+) =>
     pskCredentials;
 
 class DtlsConfig extends DefaultCoapConfig {
@@ -41,27 +44,28 @@ FutureOr<void> main() async {
     port: conf.defaultSecurePort,
   );
   final client = CoapClient(
-    uri,
     config: conf,
     pskCredentialsCallback: pskCredentialsCallback,
   );
 
   try {
     print('Sending get /test to ${uri.host}');
-    var response = await client.get('test');
+    var response = await client.get(uri.replace(path: 'test'));
     print('/test response: ${response.payloadString}');
 
     print('Sending get /multi-format (text) to ${uri.host}');
-    response = await client.get('multi-format');
+    response = await client.get(uri.replace(path: 'multi-format'));
     print('/multi-format (text) response: ${response.payloadString}');
 
     print('Sending get /multi-format (xml) to ${uri.host}');
-    response =
-        await client.get('multi-format', accept: CoapMediaType.applicationXml);
+    response = await client.get(
+      uri.replace(path: 'multi-format'),
+      accept: CoapMediaType.applicationXml,
+    );
     print('/multi-format (xml) response: ${response.payloadString}');
   } on Exception catch (e) {
     print('CoAP encountered an exception: $e');
   }
 
-  client.close();
+  await client.close();
 }

--- a/example/log_events.dart
+++ b/example/log_events.dart
@@ -16,8 +16,13 @@ import 'utils.dart';
 
 FutureOr<void> main() async {
   final conf = CoapConfig();
-  final uri = Uri(scheme: 'coap', host: 'coap.me', port: conf.defaultPort);
-  final client = CoapClient(uri, config: conf);
+  final uri = Uri(
+    scheme: 'coap',
+    host: 'coap.me',
+    port: conf.defaultPort,
+    path: 'large-create',
+  );
+  final client = CoapClient(config: conf);
 
   final opt = UriQueryOption(
     '${LinkFormatParameter.title.short}=This is an SJH Post request',
@@ -31,10 +36,10 @@ FutureOr<void> main() async {
     client.events.on<Object>().listen(print);
 
     print('Sending post /large-create to ${uri.host}');
-    await client.post('large-create', payload: payload, options: [opt]);
+    await client.post(uri, payload: payload, options: [opt]);
   } on Exception catch (e) {
     print('CoAP encountered an exception: $e');
   }
 
-  client.close();
+  await client.close();
 }

--- a/example/multi_client.dart
+++ b/example/multi_client.dart
@@ -11,34 +11,29 @@
 
 import 'dart:async';
 import 'package:coap/coap.dart';
-import 'config/coap_config.dart';
 
 FutureOr<void> main() async {
-  final conf1 = CoapConfig();
-  final uri1 = Uri(scheme: 'coap', host: 'coap.me', port: conf1.defaultPort);
-  final client1 = CoapClient(uri1, config: conf1);
+  final uri1 = Uri(scheme: 'coap', host: 'coap.me', path: 'hello');
+  final client = CoapClient();
 
-  final conf2 = CoapConfig();
   final uri2 = Uri(
     scheme: 'coap',
     host: 'californium.eclipseprojects.io',
-    port: conf2.defaultPort,
+    path: 'test',
   );
-  final client2 = CoapClient(uri2, config: conf2);
 
   try {
     print('Sending get /hello to ${uri1.host}');
-    var response = await client1.get('hello');
+    var response = await client.get(uri1);
     print('/hello response: ${response.payloadString}');
 
     print('Sending get /test to ${uri2.host}');
-    response = await client2.get('test');
+    response = await client.get(uri2);
     print('/test response: ${response.payloadString}');
   } on Exception catch (e) {
     print('CoAP encountered an exception: $e');
   }
 
   // Clean up
-  client1.close();
-  client2.close();
+  await client.close();
 }

--- a/example/ping.dart
+++ b/example/ping.dart
@@ -20,11 +20,11 @@ FutureOr<void> main() async {
     host: 'californium.eclipseprojects.io',
     port: conf.defaultPort,
   );
-  final client = CoapClient(uri, config: conf);
+  final client = CoapClient(config: conf);
 
   try {
     print('Pinging client on ${uri.host}');
-    final ok = await client.ping();
+    final ok = await client.ping(uri);
     if (ok) {
       print('Ping successful');
     } else {
@@ -34,5 +34,5 @@ FutureOr<void> main() async {
     print('CoAP encountered an exception: $e');
   }
 
-  client.close();
+  await client.close();
 }

--- a/example/post_blockwise.dart
+++ b/example/post_blockwise.dart
@@ -17,7 +17,7 @@ import 'utils.dart';
 FutureOr<void> main() async {
   final conf = CoapConfig();
   final uri = Uri(scheme: 'coap', host: 'coap.me', port: conf.defaultPort);
-  final client = CoapClient(uri, config: conf);
+  final client = CoapClient(config: conf);
 
   final opt = UriQueryOption(
     '${LinkFormatParameter.title.short}=This is an SJH Post request',
@@ -28,17 +28,20 @@ FutureOr<void> main() async {
 
   try {
     print('Sending post /large-create to ${uri.host}');
-    var response =
-        await client.post('large-create', payload: payload, options: [opt]);
+    var response = await client.post(
+      uri.replace(path: 'large-create'),
+      payload: payload,
+      options: [opt],
+    );
     print('/large-create response status: ${response.statusCodeString}');
 
     print('Sending get /large-create to ${uri.host}');
-    response = await client.get('large-create');
+    response = await client.get(uri.replace(path: 'large-create'));
     print('/large-create response:\n${response.payloadString}');
     print('E-Tags : ${response.etags.join(',')}');
   } on Exception catch (e) {
     print('CoAP encountered an exception: $e');
   }
 
-  client.close();
+  await client.close();
 }

--- a/example/post_resource.dart
+++ b/example/post_resource.dart
@@ -15,8 +15,13 @@ import 'config/coap_config.dart';
 
 FutureOr<void> main() async {
   final conf = CoapConfig();
-  final uri = Uri(scheme: 'coap', host: 'coap.me', port: conf.defaultPort);
-  final client = CoapClient(uri, config: conf);
+  final uri = Uri(
+    scheme: 'coap',
+    host: 'coap.me',
+    port: conf.defaultPort,
+    path: 'large-create',
+  );
+  final client = CoapClient(config: conf);
 
   final opt = UriQueryOption(
     '${LinkFormatParameter.title.short}=This is an SJH Post request',
@@ -24,20 +29,17 @@ FutureOr<void> main() async {
 
   try {
     print('Sending post /large-create to ${uri.host}');
-    var response = await client.post(
-      'large-create',
-      options: [opt],
-      payload: 'SJHTestPost',
-    );
+    var response =
+        await client.post(uri, options: [opt], payload: 'SJHTestPost');
     print('/large-create response status: ${response.statusCodeString}');
 
     print('Sending get /large-create to ${uri.host}');
-    response = await client.get('large-create');
+    response = await client.get(uri);
     print('/large-create response: ${response.payloadString}');
     print('E-Tags : ${response.etags.join(',')}');
   } on Exception catch (e) {
     print('CoAP encountered an exception: $e');
   }
 
-  client.close();
+  await client.close();
 }

--- a/example/put_resource.dart
+++ b/example/put_resource.dart
@@ -15,8 +15,8 @@ import 'config/coap_config.dart';
 
 FutureOr<void> main() async {
   final conf = CoapConfig();
-  final uri = Uri(scheme: 'coap', host: 'coap.me', port: conf.defaultPort);
-  final client = CoapClient(uri, config: conf);
+  final uri = Uri(scheme: 'coap', host: 'coap.me', path: 'create1');
+  final client = CoapClient(config: conf);
 
   final opt = UriQueryOption(
     '${LinkFormatParameter.title.short}=This is an SJH Put request',
@@ -25,11 +25,11 @@ FutureOr<void> main() async {
   try {
     print('Sending put /create1 to ${uri.host}');
     final response =
-        await client.put('create1', options: [opt], payload: 'SJHTestPut');
+        await client.put(uri, options: [opt], payload: 'SJHTestPut');
     print('/create1 response status: ${response.statusCodeString}');
   } on Exception catch (e) {
     print('CoAP encountered an exception: $e');
   }
 
-  client.close();
+  await client.close();
 }

--- a/example/sync_vs_async.dart
+++ b/example/sync_vs_async.dart
@@ -19,12 +19,13 @@ FutureOr<void> main() async {
     scheme: 'coap',
     host: 'californium.eclipseprojects.io',
     port: conf.defaultPort,
+    path: 'test',
   );
-  final client = CoapClient(uri, config: conf);
+  final client = CoapClient(config: conf);
 
   try {
     // Warm up (create socket etc.)
-    await client.get('test');
+    await client.get(uri);
 
     final stopwatch = Stopwatch()..start();
 
@@ -32,7 +33,7 @@ FutureOr<void> main() async {
     final futures = <Future<void>>[];
     for (var i = 0; i < 10; i++) {
       futures.add(
-        client.get('test').then((final resp) {
+        client.get(uri).then((final resp) {
           if (resp.responseCode != ResponseCode.content) {
             print('Request failed!');
           }
@@ -49,7 +50,7 @@ FutureOr<void> main() async {
 
     print('Sending 10 sync requests...');
     for (var i = 0; i < 10; i++) {
-      final resp = await client.get('test');
+      final resp = await client.get(uri);
       if (resp.responseCode != ResponseCode.content) {
         print('Request failed!');
       }
@@ -60,5 +61,5 @@ FutureOr<void> main() async {
     print('CoAP encountered an exception: $e');
   }
 
-  client.close();
+  await client.close();
 }

--- a/lib/src/coap_message.dart
+++ b/lib/src/coap_message.dart
@@ -593,6 +593,12 @@ abstract class CoapMessage {
     timedOutHook = msg.timedOutHook;
   }
 
+  /// Callback for initializing the retransmission of this [CoapMessage].
+  ///
+  /// If the callback is [Null], this message is not intended to be
+  /// retransmitted.
+  void Function()? retransmissionCallback;
+
   String? get _formattedOptions {
     final options = getAllOptions();
 

--- a/lib/src/coap_observe_client_relation.dart
+++ b/lib/src/coap_observe_client_relation.dart
@@ -67,7 +67,7 @@ class CoapObserveClientRelation extends Stream<CoapResponse> {
 
   /// Create a cancellation request
   @internal
-  CoapRequest newCancel() => CoapRequest.newGet()
+  CoapRequest newCancel() => CoapRequest.newGet(_request.uri)
     // Copy options, but set Observe to cancel
     ..setOptions(_request.getAllOptions())
     ..observe = ObserveRegistration.deregister.value

--- a/lib/src/coap_request.dart
+++ b/lib/src/coap_request.dart
@@ -27,11 +27,13 @@ import 'option/string_option.dart';
 class CoapRequest extends CoapMessage {
   /// Initializes a request message.
   /// Defaults to confirmable
-  CoapRequest(this.method, {final bool confirmable = true})
+  CoapRequest(this.method, final Uri uri, {final bool confirmable = true})
       : super(
           method.coapCode,
           confirmable ? CoapMessageType.con : CoapMessageType.non,
-        );
+        ) {
+    this.uri = uri;
+  }
 
   /// The request method(code)
   final RequestMethod method;
@@ -48,7 +50,9 @@ class CoapRequest extends CoapMessage {
   /// Indicates whether this request is a multicast request or not.
   bool get isMulticast => destination?.isMulticast ?? false;
 
-  String? scheme = 'coap';
+  var _scheme = 'coap';
+
+  String get scheme => _scheme;
 
   /// Specifies the target resource of a request to a CoAP origin server.
   ///
@@ -97,7 +101,7 @@ class CoapRequest extends CoapMessage {
       uriHost = host;
     }
     if (port <= 0) {
-      if (value.scheme.isNotEmpty || value.scheme == CoapConstants.uriScheme) {
+      if (value.scheme == CoapConstants.uriScheme) {
         port = CoapConstants.defaultPort;
       } else if (value.scheme == CoapConstants.secureUriScheme) {
         port = CoapConstants.defaultSecurePort;
@@ -110,7 +114,10 @@ class CoapRequest extends CoapMessage {
     if (query.isNotEmpty) {
       uriQuery = value.query;
     }
-    scheme = value.scheme;
+    // TODO(JKRhb): Check for supported schemes
+    if (value.scheme.isNotEmpty) {
+      _scheme = value.scheme;
+    }
   }
 
   /// Uri's
@@ -205,7 +212,6 @@ class CoapRequest extends CoapMessage {
   @internal
   set endpoint(final Endpoint? endpoint) {
     super.id = endpoint!.nextMessageId;
-    super.destination = endpoint.destination;
     _endpoint = endpoint;
   }
 
@@ -213,32 +219,44 @@ class CoapRequest extends CoapMessage {
   String toString() => '\n<<< Request Message >>>${super.toString()}';
 
   /// Construct a GET request.
-  factory CoapRequest.newGet({final bool confirmable = true}) =>
-      CoapRequest(RequestMethod.get, confirmable: confirmable);
+  factory CoapRequest.newGet(final Uri uri, {final bool confirmable = true}) =>
+      CoapRequest(RequestMethod.get, uri, confirmable: confirmable);
 
   /// Construct a POST request.
-  factory CoapRequest.newPost({final bool confirmable = true}) =>
-      CoapRequest(RequestMethod.post, confirmable: confirmable);
+  factory CoapRequest.newPost(final Uri uri, {final bool confirmable = true}) =>
+      CoapRequest(RequestMethod.post, uri, confirmable: confirmable);
 
   /// Construct a PUT request.
-  factory CoapRequest.newPut({final bool confirmable = true}) =>
-      CoapRequest(RequestMethod.put, confirmable: confirmable);
+  factory CoapRequest.newPut(final Uri uri, {final bool confirmable = true}) =>
+      CoapRequest(RequestMethod.put, uri, confirmable: confirmable);
 
   /// Construct a DELETE request.
-  factory CoapRequest.newDelete({final bool confirmable = true}) =>
-      CoapRequest(RequestMethod.delete, confirmable: confirmable);
+  factory CoapRequest.newDelete(
+    final Uri uri, {
+    final bool confirmable = true,
+  }) =>
+      CoapRequest(RequestMethod.delete, uri, confirmable: confirmable);
 
   /// Construct a FETCH request.
-  factory CoapRequest.newFetch({final bool confirmable = true}) =>
-      CoapRequest(RequestMethod.fetch, confirmable: confirmable);
+  factory CoapRequest.newFetch(
+    final Uri uri, {
+    final bool confirmable = true,
+  }) =>
+      CoapRequest(RequestMethod.fetch, uri, confirmable: confirmable);
 
   /// Construct a PATCH request.
-  factory CoapRequest.newPatch({final bool confirmable = true}) =>
-      CoapRequest(RequestMethod.patch, confirmable: confirmable);
+  factory CoapRequest.newPatch(
+    final Uri uri, {
+    final bool confirmable = true,
+  }) =>
+      CoapRequest(RequestMethod.patch, uri, confirmable: confirmable);
 
   /// Construct a iPATCH request.
-  factory CoapRequest.newIPatch({final bool confirmable = true}) =>
-      CoapRequest(RequestMethod.ipatch, confirmable: confirmable);
+  factory CoapRequest.newIPatch(
+    final Uri uri, {
+    final bool confirmable = true,
+  }) =>
+      CoapRequest(RequestMethod.ipatch, uri, confirmable: confirmable);
 
   CoapRequest.fromParsed(
     this.method, {

--- a/lib/src/codec/udp/message_encoder.dart
+++ b/lib/src/codec/udp/message_encoder.dart
@@ -106,8 +106,7 @@ Uint8Buffer serializeUdpMessage(final CoapMessage message) {
 }
 
 bool _shouldBeSkipped(final Option<Object?> opt, final CoapMessage message) {
-  if (opt is UriHostOption &&
-      InternetAddress.tryParse(opt.value) == message.destination) {
+  if (opt is UriHostOption && InternetAddress.tryParse(opt.value) != null) {
     return true;
   }
 

--- a/lib/src/event/coap_event_bus.dart
+++ b/lib/src/event/coap_event_bus.dart
@@ -149,13 +149,28 @@ enum CoapOrigin {
 /// Data received Event
 class CoapMessageReceivedEvent {
   /// Construction
-  CoapMessageReceivedEvent(this.coapMessage, this.address);
+  CoapMessageReceivedEvent(
+    this.coapMessage,
+    this.address,
+    this.port, {
+    required this.scheme,
+  });
 
   /// The data
   final CoapMessage? coapMessage;
 
-  /// The address
-  InternetAddress address;
+  /// The [InternetAddress] the [coapMessage] was received from.
+  final InternetAddress address;
+
+  /// The URI scheme associated with the [coapMessage] (e.g., `coap` for CoAP
+  /// over UDP).
+  final String scheme;
+
+  /// The port the [coapMessage] was received from.
+  final int port;
+
+  /// Generates a [Uri] pointing the peer the message was received from.
+  Uri get peerUri => Uri(host: address.host, scheme: scheme, port: port);
 
   @override
   String toString() => '$runtimeType:\n$coapMessage from ${address.address}';

--- a/lib/src/network/cache.dart
+++ b/lib/src/network/cache.dart
@@ -1,0 +1,69 @@
+/// Caches entries of type [T], using values of type [S] as the cache key.
+class Cache<S, T> {
+  /// Generate a new [Cache] that uses the given [hashFunction] for determining
+  /// the eventual cache key for the chosen key type [S].
+  ///
+  /// If no [hashFunction] is passend, then [Object.hashCode] will be used
+  /// instead.
+  Cache([final int Function(S cacheKey)? hashFunction])
+      : _hashFunction = hashFunction ?? _defaultHashFunction;
+
+  final _cache = <int, _CacheEntry<T>>{};
+
+  final int Function(S cacheKey) _hashFunction;
+
+  bool _isFresh(final _CacheEntry<T> cacheEntry) {
+    final cacheValidity = cacheEntry.timeToLive;
+
+    if (cacheValidity == null || cacheValidity == Duration.zero) {
+      return true;
+    }
+
+    final timeInCache = DateTime.now().difference(cacheEntry.timeStamp);
+
+    return timeInCache > cacheValidity;
+  }
+
+  /// Retrieves a value of type [T] from the cache, if present, using a given
+  /// [key].
+  ///
+  /// If the cache entry was created with a specified time-to-live, the entry
+  /// will be cleaned up if the time-to-live period has expired.
+  /// In this case, the method will return [Null].
+  T? retrieve(final S key) {
+    final cacheValue = _cache[_hashFunction(key)];
+
+    if (cacheValue == null) {
+      return null;
+    }
+
+    if (_isFresh(cacheValue)) {
+      return cacheValue.value;
+    }
+
+    _cache.remove(key);
+    return null;
+  }
+
+  static int _defaultHashFunction<S>(final S key) => key.hashCode;
+
+  /// Removes an entry from the cache, if present, using the given [key].
+  void remove(final S key) => _cache.remove(_cache[_hashFunction(key)]);
+
+  /// Adds a new [value] with an optional [timeToLive] to the cache, using
+  /// the given [key].
+  ///
+  /// If the key should already be present, it will be overridden.
+  void save(final S key, final T value, [final Duration? timeToLive]) =>
+      _cache[_hashFunction(key)] = _CacheEntry(value, timeToLive);
+}
+
+class _CacheEntry<T> {
+  _CacheEntry(this.value, this.timeToLive) : timeStamp = DateTime.now();
+
+  final T value;
+
+  final DateTime timeStamp;
+
+  final Duration? timeToLive;
+}

--- a/lib/src/network/coap_network_tcp.dart
+++ b/lib/src/network/coap_network_tcp.dart
@@ -29,18 +29,17 @@ class CoapNetworkTCP implements CoapINetwork {
 
   final CoapEventBus eventBus;
 
-  @override
   final InternetAddress address;
 
-  @override
   final int port;
 
-  @override
   final InternetAddress bindAddress;
 
   bool _shouldReinitialize = true;
 
   final bool isTls;
+
+  String get _scheme => isTls ? 'coaps+tcp' : 'coap+tcp';
 
   final SecurityContext? _tlsContext;
 
@@ -50,11 +49,11 @@ class CoapNetworkTCP implements CoapINetwork {
   @override
   bool isClosed = true;
 
-  @override
   void send(
-    final CoapMessage message, [
-    final InternetAddress? _,
-  ]) {
+    final CoapMessage message,
+    final InternetAddress address,
+    final int port,
+  ) {
     if (isClosed) {
       return;
     }
@@ -62,7 +61,7 @@ class CoapNetworkTCP implements CoapINetwork {
     _socket?.add(message.toTcpPayload());
   }
 
-  @override
+  // TODO(JKRhb): Rework initialization
   Future<void> init() async {
     if (!isClosed || !_shouldReinitialize) {
       return;
@@ -101,7 +100,15 @@ class CoapNetworkTCP implements CoapINetwork {
     socket?.listen(
       (final data) {
         final message = CoapMessage.fromTcpPayload(Uint8Buffer()..addAll(data));
-        eventBus.fire(CoapMessageReceivedEvent(message, address));
+        // TODO(JKRhb): Update once actually implementing TCP
+        eventBus.fire(
+          CoapMessageReceivedEvent(
+            message,
+            address,
+            port,
+            scheme: _scheme,
+          ),
+        );
       },
       // ignore: avoid_types_on_closure_parameters
       onError: (final Object e, final StackTrace s) =>
@@ -119,5 +126,10 @@ class CoapNetworkTCP implements CoapINetwork {
         });
       },
     );
+  }
+
+  @override
+  void sendMessage(final CoapMessage coapRequest, final Uri uri) {
+    // TODO(JKRhb): implement sendRequest
   }
 }

--- a/lib/src/network/coap_network_udp.dart
+++ b/lib/src/network/coap_network_udp.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 
 import 'package:typed_data/typed_data.dart';
 
+import '../coap_constants.dart';
 import '../coap_message.dart';
 import '../event/coap_event_bus.dart';
 import 'coap_inetwork.dart';
@@ -16,85 +17,107 @@ import 'coap_inetwork.dart';
 /// UDP network
 class CoapNetworkUDP implements CoapINetwork {
   /// Initialize with an address and a port
-  CoapNetworkUDP(
-    this.address,
-    this.port,
-    this.bindAddress, {
-    final String namespace = '',
-  }) : eventBus = CoapEventBus(namespace: namespace);
-
-  @override
-  final InternetAddress address;
-
-  @override
-  final int port;
-
-  @override
-  final InternetAddress bindAddress;
-
-  bool _shouldReinitialize = true;
-  bool get shouldReinitialize => _shouldReinitialize;
+  CoapNetworkUDP({final String namespace = ''})
+      : eventBus = CoapEventBus(namespace: namespace);
 
   final CoapEventBus eventBus;
 
-  RawDatagramSocket? _socket;
-  RawDatagramSocket? get socket => _socket;
+  RawDatagramSocket? _ipv4Socket;
+
+  RawDatagramSocket? _ipv6Socket;
+
+  Future<RawDatagramSocket> _createClient(final InternetAddress bindAddress) =>
+      RawDatagramSocket.bind(bindAddress, 0);
+
+  Future<RawDatagramSocket> _checkExistingClient(
+    final RawDatagramSocket? existingClient,
+    final InternetAddress bindAddress,
+  ) async {
+    final RawDatagramSocket newClient;
+
+    if (existingClient == null) {
+      eventBus.fire(CoapSocketInitEvent());
+      newClient = await _createClient(bindAddress);
+      _receive(newClient);
+    } else {
+      return existingClient;
+    }
+
+    return newClient;
+  }
+
+  Future<RawDatagramSocket> _obtainClient(final InternetAddress address) async {
+    final internetAddressType = address.type;
+
+    final RawDatagramSocket client;
+    if (internetAddressType == InternetAddressType.IPv4) {
+      client = await _checkExistingClient(_ipv4Socket, InternetAddress.anyIPv4);
+      _ipv4Socket = client;
+    } else {
+      client = await _checkExistingClient(_ipv6Socket, InternetAddress.anyIPv6);
+      _ipv6Socket = client;
+    }
+
+    return client;
+  }
 
   @override
-  bool isClosed = true;
+  bool isClosed = false;
 
   @override
-  void send(final CoapMessage coapMessage) {
+  Future<void> sendMessage(final CoapMessage coapRequest, final Uri uri) async {
     if (isClosed) {
       return;
     }
 
-    _socket!.send(
-      coapMessage.toUdpPayload(),
-      coapMessage.destination ?? address,
+    final address = await lookupHost(uri);
+    final uriPort = uri.port;
+    final port = uriPort != 0 ? uriPort : CoapConstants.defaultPort;
+
+    final socket = await _obtainClient(address);
+    socket.send(
+      coapRequest.toUdpPayload(),
+      address,
       port,
     );
-  }
-
-  @override
-  Future<void> init() async {
-    if (!isClosed || !shouldReinitialize) {
-      return;
-    }
-
-    await bind();
-    _receive();
-
-    isClosed = false;
+    enableRetransmission(coapRequest);
   }
 
   @override
   void close() {
-    _shouldReinitialize = false;
-    _socket?.close();
+    if (!isClosed) {
+      _ipv4Socket?.close();
+      _ipv4Socket = null;
+      _ipv6Socket?.close();
+      _ipv6Socket = null;
+    }
     isClosed = true;
   }
 
   Future<void> bind() async {
     eventBus.fire(CoapSocketInitEvent());
-
-    // Use port 0 to generate a random source port
-    _socket = await RawDatagramSocket.bind(bindAddress, 0);
   }
 
-  void _receive() {
-    _socket?.listen(
+  void _receive(final RawDatagramSocket socket) {
+    socket.listen(
       (final e) {
         switch (e) {
           case RawSocketEvent.read:
-            final d = _socket?.receive();
+            final d = socket.receive();
             if (d == null) {
               return;
             }
             // d.address can differ from address with multicast
             final message =
                 CoapMessage.fromUdpPayload(Uint8Buffer()..addAll(d.data));
-            eventBus.fire(CoapMessageReceivedEvent(message, d.address));
+            eventBus.fire(
+              CoapMessageReceivedEvent(
+                message,
+                d.address,
+                d.port,
+                scheme: CoapConstants.secureUriScheme,
+              ),
+            );
             break;
           // When we manually closed the socket (no need to do anything)
           case RawSocketEvent.closed:
@@ -107,11 +130,6 @@ class CoapNetworkUDP implements CoapINetwork {
       // ignore: avoid_types_on_closure_parameters
       onError: (final Object e, final StackTrace s) =>
           eventBus.fire(CoapSocketErrorEvent(e, s)),
-      // Socket stream is done and can no longer be listened to
-      onDone: () {
-        isClosed = true;
-        init();
-      },
     );
   }
 }

--- a/lib/src/network/credentials/psk_credentials.dart
+++ b/lib/src/network/credentials/psk_credentials.dart
@@ -15,6 +15,7 @@ import 'dart:typed_data';
 /// are known in advance.
 typedef PskCredentialsCallback = PskCredentials Function(
   Uint8List identityHint,
+  Uri uri,
 );
 
 /// Credentials used for PSK Cipher Suites consisting of an [identity]

--- a/lib/src/stack/blockwise_status.dart
+++ b/lib/src/stack/blockwise_status.dart
@@ -7,7 +7,8 @@
 
 import 'package:typed_data/typed_data.dart';
 
-import '../../coap.dart';
+import '../coap_media_type.dart';
+import '../option/coap_block_option.dart';
 
 /// Represents the status of a blockwise transfer of a request or a response.
 class BlockwiseStatus {

--- a/lib/src/stack/layers/blockwise.dart
+++ b/lib/src/stack/layers/blockwise.dart
@@ -128,7 +128,7 @@ class BlockwiseLayer extends BaseLayer {
           _earlyBlock2Negotiation(exchange, request);
 
           // Assemble and deliver
-          final assembled = CoapRequest(request.method);
+          final assembled = CoapRequest(request.method, request.uri);
           _assembleMessage(status, assembled, request);
 
           exchange.request = assembled;
@@ -326,7 +326,7 @@ class BlockwiseLayer extends BaseLayer {
           final m = block2.m;
 
           final nextBlock = Block2Option.fromParts(num, szx, m: m);
-          final block = CoapRequest(request.method)
+          final block = CoapRequest(request.method, request.uri)
             ..endpoint = request.endpoint
             // NON could make sense over SMS or similar transports
             ..setOptions(request.getAllOptions())
@@ -413,7 +413,7 @@ class BlockwiseLayer extends BaseLayer {
   ) {
     final num = status.currentNUM;
     final szx = status.currentSZX;
-    final block = CoapRequest(request.method)
+    final block = CoapRequest(request.method, request.uri)
       ..endpoint = request.endpoint
       ..setOptions(request.getAllOptions())
       ..destination = request.destination

--- a/lib/src/stack/layers/observe.dart
+++ b/lib/src/stack/layers/observe.dart
@@ -235,7 +235,7 @@ class _ReregistrationContext {
   void _timerElapsed() {
     final request = _exchange.request;
     if (!request.isCancelled) {
-      final refresh = CoapRequest.newGet()
+      final refresh = CoapRequest.newGet(request.uri)
         ..setOptions(request.getAllOptions())
         // Make sure Observe is set and zero
         ..observe = ObserveRegistration.register.value

--- a/lib/src/stack/layers/reliability.dart
+++ b/lib/src/stack/layers/reliability.dart
@@ -36,11 +36,13 @@ class ReliabilityLayer extends BaseLayer {
     final CoapRequest request,
   ) {
     if (request.type == CoapMessageType.con) {
-      _prepareRetransmission(
-        exchange,
-        request,
-        (final ctx) => sendRequest(exchange, request),
-      );
+      // Hack to get this to work with the network design
+      // Should be reworked in future versions.
+      request.retransmissionCallback = () => _prepareRetransmission(
+            exchange,
+            request,
+            (final ctx) => sendRequest(exchange, request),
+          );
     }
 
     super.sendRequest(exchange, request);
@@ -61,11 +63,13 @@ class ReliabilityLayer extends BaseLayer {
     }
 
     if (response.type == CoapMessageType.con) {
-      _prepareRetransmission(
-        exchange,
-        response,
-        (final ctx) => sendResponse(exchange, response),
-      );
+      // Hack to get this to work with the network design
+      // Should be reworked in future versions.
+      response.retransmissionCallback = () => _prepareRetransmission(
+            exchange,
+            response,
+            (final ctx) => sendResponse(exchange, response),
+          );
     }
 
     super.sendResponse(exchange, response);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,6 @@ dependencies:
   meta: ^1.8.0
   path: ^1.8.2
   string_scanner: ^1.1.1
-  synchronized: ^3.0.0+2
   typed_data: ^1.3.1
   yaml: ^3.1.1
 

--- a/test/coap_datagram_read_write_test.dart
+++ b/test/coap_datagram_read_write_test.dart
@@ -235,9 +235,10 @@ void main() {
         ..addAll(
           List<int>.generate(tokenLength, ((final index) => index % 256)),
         ));
-      final request = CoapRequest(RequestMethod.get)
-        ..id = 5
-        ..token = token;
+      final request =
+          CoapRequest(RequestMethod.get, Uri.parse('coap://example.org'))
+            ..id = 5
+            ..token = token;
 
       final payload = request.toUdpPayload();
       expect(

--- a/test/coap_message_api_test.dart
+++ b/test/coap_message_api_test.dart
@@ -49,7 +49,8 @@ void main() {
   });
 
   test('Options', () {
-    final message = CoapRequest(RequestMethod.get);
+    final emptyUri = Uri();
+    final message = CoapRequest(RequestMethod.get, emptyUri);
     final opt1 = UriQueryOption.parse(Uint8Buffer());
     expect(
       () => OptionType.fromTypeNumber(9000),
@@ -228,7 +229,8 @@ void main() {
   });
 
   test('Uri path', () {
-    final message = CoapRequest(RequestMethod.get)..isTimedOut = true;
+    final emptyUri = Uri();
+    final message = CoapRequest(RequestMethod.get, emptyUri)..isTimedOut = true;
     expect(message.uriPaths.length, 0);
     for (final path in ['', '/']) {
       message.uriPath = path;
@@ -278,7 +280,8 @@ void main() {
   });
 
   test('Uri query', () {
-    final message = CoapRequest(RequestMethod.get);
+    final emptyUri = Uri();
+    final message = CoapRequest(RequestMethod.get, emptyUri);
     expect(message.uriQueries.length, 0);
     message.uriQuery = 'a&uri=1&query=2';
     expect(message.uriQueries.length, 3);
@@ -405,19 +408,20 @@ void main() {
   ///
   /// [RFC 7252, Appendix B]: https://www.rfc-editor.org/rfc/rfc7252#appendix-B
   test('Multiple URI options', () {
-    final message1 = CoapRequest(RequestMethod.get)
+    final emptyUri = Uri();
+    final message1 = CoapRequest(RequestMethod.get, emptyUri)
       ..uriHost = '[2001:db8::2:1]'
       ..uriPort = 5683;
 
     expect(message1.uri.toString(), 'coap://[2001:db8::2:1]/');
 
-    final message2 = CoapRequest(RequestMethod.get)
+    final message2 = CoapRequest(RequestMethod.get, emptyUri)
       ..uriHost = 'example.net'
       ..uriPort = 5683;
 
     expect(message2.uri.toString(), 'coap://example.net/');
 
-    final message3 = CoapRequest(RequestMethod.get)
+    final message3 = CoapRequest(RequestMethod.get, emptyUri)
       ..uriHost = 'example.net'
       ..uriPort = 5683
       ..addUriPath('.well-known')
@@ -425,7 +429,7 @@ void main() {
 
     expect(message3.uri.toString(), 'coap://example.net/.well-known/core');
 
-    final message4 = CoapRequest(RequestMethod.get)
+    final message4 = CoapRequest(RequestMethod.get, emptyUri)
       ..uriHost = 'xn--18j4d.example'
       ..uriPort = 5683
       ..addUriPath(utf8.decode(hex.decode('E38193E38293E381ABE381A1E381AF')));
@@ -435,7 +439,7 @@ void main() {
       'coap://xn--18j4d.example/%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF',
     );
 
-    final message5 = CoapRequest(RequestMethod.get)
+    final message5 = CoapRequest(RequestMethod.get, emptyUri)
       ..destination = InternetAddress('198.51.100.1')
       ..uriPort = 61616
       ..addUriPath('')

--- a/test/coap_message_encode_decode_test.dart
+++ b/test/coap_message_encode_decode_test.dart
@@ -148,7 +148,8 @@ void main() {
     }
 
     void testMessage(final int testNo) {
-      final CoapMessage msg = CoapRequest(RequestMethod.get)
+      final emptyUri = Uri();
+      final CoapMessage msg = CoapRequest(RequestMethod.get, emptyUri)
         ..id = 12345
         ..setPayload('payload');
       final data = serializeUdpMessage(msg);
@@ -166,7 +167,8 @@ void main() {
     }
 
     void testMessageWithOptions(final int testNo) {
-      final CoapMessage msg = CoapRequest(RequestMethod.get)
+      final emptyUri = Uri();
+      final CoapMessage msg = CoapRequest(RequestMethod.get, emptyUri)
         ..id = 12345
         ..setPayload('payload')
         ..addOption(
@@ -202,7 +204,8 @@ void main() {
     }
 
     void testMessageWithExtendedOption(final int testNo) {
-      final CoapMessage msg = CoapRequest(RequestMethod.get)
+      final emptyUri = Uri();
+      final CoapMessage msg = CoapRequest(RequestMethod.get, emptyUri)
         ..id = 12345
         ..addOption(ContentFormatOption(0));
       expect(msg.getFirstOption<ContentFormatOption>()!.value, 0);
@@ -231,15 +234,17 @@ void main() {
     }
 
     void testRequestParsing(final int testNo) {
-      final request = CoapRequest(RequestMethod.post, confirmable: false)
-        ..id = 7
-        ..token = (typed.Uint8Buffer()..addAll(<int>[11, 82, 165, 77, 3]))
-        ..addIfMatchOpaque(typed.Uint8Buffer()..addAll(<int>[34, 239]))
-        ..addIfMatchOpaque(
-          typed.Uint8Buffer()..addAll(<int>[88, 12, 254, 157, 5]),
-        )
-        ..contentType = CoapMediaType.fromIntValue(40)
-        ..accept = CoapMediaType.fromIntValue(40);
+      final emptyUri = Uri();
+      final request =
+          CoapRequest(RequestMethod.post, emptyUri, confirmable: false)
+            ..id = 7
+            ..token = (typed.Uint8Buffer()..addAll(<int>[11, 82, 165, 77, 3]))
+            ..addIfMatchOpaque(typed.Uint8Buffer()..addAll(<int>[34, 239]))
+            ..addIfMatchOpaque(
+              typed.Uint8Buffer()..addAll(<int>[88, 12, 254, 157, 5]),
+            )
+            ..contentType = CoapMediaType.fromIntValue(40)
+            ..accept = CoapMediaType.fromIntValue(40);
 
       final bytes = serializeUdpMessage(request);
       checkData(bytes, testNo);


### PR DESCRIPTION
I started a new attempt at moving the URL argument from the client to the request methods, making it easier to reuse clients for multiple requests. In theory, this should also make it more efficient to make multiple requests to different endpoints, as they can all use the same socket(s).

At the moment, this PR is still WIP and should be considered experimental, since for now only UDP is covered. It will also require more discussion and needs to address the concerns raised in #93. I will try to come up with a proper solution after #149 is merged, as the `dtls2` API should make it much easier to also implement this PR's approach for DTLS.