### PR TITLE
refactor: properly handle network byte order in IntegerOption

### DIFF
--- a/lib/src/codec/udp/message_decoder.dart
+++ b/lib/src/codec/udp/message_decoder.dart
@@ -5,8 +5,6 @@
  * Copyright :  S.Hamblett
  */
 
-import 'dart:typed_data';
-
 import 'package:typed_data/typed_data.dart';
 
 import '../../coap_code.dart';
@@ -100,11 +98,7 @@ CoapMessage? deserializeUdpMessage(final Uint8Buffer data) {
       // Read option
       try {
         final optionType = OptionType.fromTypeNumber(currentOption);
-        var optionBytes = reader.readBytes(optionLength);
-        if (Endian.host == Endian.little &&
-            optionType.optionFormat is OptionFormat<int>) {
-          optionBytes = Uint8Buffer()..addAll(optionBytes.reversed);
-        }
+        final optionBytes = reader.readBytes(optionLength);
         final option = optionType.parse(optionBytes);
         options.add(option);
       } on UnknownElectiveOptionException catch (_) {

--- a/lib/src/codec/udp/message_encoder.dart
+++ b/lib/src/codec/udp/message_encoder.dart
@@ -15,7 +15,6 @@ import '../../coap_constants.dart';
 import '../../coap_message.dart';
 import '../../coap_message_type.dart';
 import '../../coap_request.dart';
-import '../../option/coap_option_type.dart';
 import '../../option/integer_option.dart';
 import '../../option/option.dart';
 import '../../option/string_option.dart';
@@ -89,13 +88,7 @@ Uint8Buffer serializeUdpMessage(final CoapMessage message) {
       writer.write(optionLength - 269, 16);
     }
 
-    // Write option value, reverse byte order for numeric options
-    if (opt.type.optionFormat == OptionFormat.integer) {
-      final reversedBuffer = Uint8Buffer()..addAll(opt.byteValue.reversed);
-      writer.writeBytes(reversedBuffer);
-    } else {
-      writer.writeBytes(opt.byteValue);
-    }
+    writer.writeBytes(opt.byteValue);
 
     lastOptionNumber = optNum;
   }

--- a/lib/src/option/integer_option.dart
+++ b/lib/src/option/integer_option.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_redundant_argument_values
+
 import 'dart:typed_data';
 
 import 'package:typed_data/typed_data.dart';
@@ -5,6 +7,15 @@ import 'package:typed_data/typed_data.dart';
 import '../coap_media_type.dart';
 import 'coap_option_type.dart';
 import 'option.dart';
+
+/// The byte order used when converting to and from binary integer option
+/// values.
+///
+/// As originally specified in [RFC 1700], a big-endian order is used for the
+/// Internet protocol suite.
+///
+/// [RFC 1700]: https://www.rfc-editor.org/rfc/rfc1700
+const _networkByteOrder = Endian.big;
 
 abstract class IntegerOption extends Option<int> {
   IntegerOption(this.type, this.value) : byteValue = _bytesFromValue(value);
@@ -24,35 +35,35 @@ abstract class IntegerOption extends Option<int> {
   final int value;
 
   static int _valueFromBytes(final Uint8Buffer byteValue) {
-    // TODO(JKRhb): The handling of endianness should be revisited here.
     switch (byteValue.length) {
       case 0:
         return 0;
       case 1:
         return byteValue[0];
       case 2:
-        return ByteData.view(byteValue.buffer).getUint16(0, Endian.host);
+        return ByteData.view(byteValue.buffer).getUint16(0, _networkByteOrder);
       case 3:
       case 4:
         final paddedBytes = Uint8List(4)..setAll(0, byteValue);
-        return ByteData.view(paddedBytes.buffer).getUint32(0, Endian.host);
+        return ByteData.view(paddedBytes.buffer)
+            .getUint32(0, _networkByteOrder);
       default:
         final paddedBytes = Uint8List(8)..setAll(0, byteValue);
-        return ByteData.view(paddedBytes.buffer).getUint64(0, Endian.host);
+        return ByteData.view(paddedBytes.buffer)
+            .getUint64(0, _networkByteOrder);
     }
   }
 
   static Uint8Buffer _bytesFromValue(final int value) {
-    // TODO(JKRhb): The handling of endianness should be revisited here.
-    ByteData data;
+    final ByteData data;
     if (value < 0 || value >= (1 << 32)) {
-      data = ByteData(8)..setUint64(0, value);
+      data = ByteData(8)..setUint64(0, value, _networkByteOrder);
     } else if (value < (1 << 8)) {
       data = ByteData(1)..setUint8(0, value);
     } else if (value < (1 << 16)) {
-      data = ByteData(2)..setUint16(0, value, Endian.host);
+      data = ByteData(2)..setUint16(0, value, _networkByteOrder);
     } else {
-      data = ByteData(4)..setUint32(0, value, Endian.host);
+      data = ByteData(4)..setUint32(0, value, _networkByteOrder);
     }
 
     return _trimData(data);

--- a/lib/src/option/integer_option.dart
+++ b/lib/src/option/integer_option.dart
@@ -17,9 +17,23 @@ import 'option.dart';
 /// [RFC 1700]: https://www.rfc-editor.org/rfc/rfc1700
 const _networkByteOrder = Endian.big;
 
+/// Option format for non-negative integer values represented in network byte
+/// order.
+///
+/// See [RFC 7252, section 3.2] for more information.
+///
+/// [RFC 7252, section 3.2]: https://www.rfc-editor.org/rfc/rfc7252#section-3.2
 abstract class IntegerOption extends Option<int> {
+  /// Create an [IntegerOption] of a specified [type], encoding the given
+  /// [value].
+  ///
+  /// The [value] will be encoded using network byte order.
   IntegerOption(this.type, this.value) : byteValue = _bytesFromValue(value);
 
+  /// Create an [IntegerOption] of a specified [type], parsing the given
+  /// encoded [byteValue].
+  ///
+  /// The [byteValue] needs to be encoded in network byte order.
   IntegerOption.parse(this.type, this.byteValue)
       : value = _valueFromBytes(byteValue);
 

--- a/test/coap_option_test.dart
+++ b/test/coap_option_test.dart
@@ -141,18 +141,9 @@ void main() {
       expect(toBytes(BlockSize.blockSize16, 0, m: false), <int>[]);
       expect(toBytes(BlockSize.blockSize16, 1, m: false), [0x10]);
       expect(toBytes(BlockSize.blockSize16, 15, m: false), [0xf0]);
-      expect(
-        toBytes(BlockSize.blockSize16, 16, m: false),
-        [0x01, 0x00].reversed,
-      );
-      expect(
-        toBytes(BlockSize.blockSize16, 79, m: false),
-        [0x04, 0xf0].reversed,
-      );
-      expect(
-        toBytes(BlockSize.blockSize16, 113, m: false),
-        [0x07, 0x10].reversed,
-      );
+      expect(toBytes(BlockSize.blockSize16, 16, m: false), [0x01, 0x00]);
+      expect(toBytes(BlockSize.blockSize16, 79, m: false), [0x04, 0xf0]);
+      expect(toBytes(BlockSize.blockSize16, 113, m: false), [0x07, 0x10]);
 
       expect(
         () => toBytes(BlockSize.blockSize16, 26387, m: false),


### PR DESCRIPTION
I've got the impression that the handling of endianness in the `IntegerOption`s could already be fine by now. Therefore, I wanted to propose removing the two TODOs within the `IntegerOption` class. I am not entirely sure about big endian platforms, though. However, doing some manual testing did not reveal a problem so far.

Do you think the current state of this kind of option is fine, @JosefWN? Or do you think we should add some more formal testing in this regard?