### PR TITLE
fix: bump dtls2 to version 0.11.0, handle all exceptions during connect

### DIFF
--- a/lib/src/network/coap_network_openssl.dart
+++ b/lib/src/network/coap_network_openssl.dart
@@ -142,7 +142,7 @@ class CoapNetworkUDPOpenSSL extends CoapNetworkUDP {
         hostname: _hostname,
         timeout: CoapINetwork.initTimeout,
       );
-    } on TimeoutException {
+    } on Exception {
       await close();
       rethrow;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   build: ^2.3.0
   collection: ^1.16.0
   convert: ^3.0.2
-  dtls2: ^0.10.0
+  dtls2: ^0.11.0
   event_bus: ^2.0.0
   meta: ^1.8.0
   path: ^1.8.2


### PR DESCRIPTION
This PR bumps `dtls2` to version 0.11.0 which solves a problem that could occur if the use of PSK ciphers suites was indicated with no PSK callback defined. In this case (e.g., in the `get_resource_secure` example when commenting out the callback argument) a segmentation fault could occur with not further information. The new version fixes this problem.

To be able to properly handle all exceptions that can occur during the connection establishment, the `on` clause now captures all `Exception` objects, closes the client, and rethrows them. 