### PR TITLE
refactor: replace OSCORE Interfaces with Mixins

### DIFF
--- a/lib/src/option/coap_block_option.dart
+++ b/lib/src/option/coap_block_option.dart
@@ -85,7 +85,7 @@ enum BlockOptionType {
 
 /// This class describes the block options of the CoAP messages
 abstract class CoapBlockOption extends IntegerOption
-    implements OscoreOptionClassE, OscoreOptionClassU {
+    with OscoreOptionClassE, OscoreOptionClassU {
   String get _szxErrorMessage =>
       'Encountered reserved SZX value 7 in $runtimeType.';
 

--- a/lib/src/option/empty_option.dart
+++ b/lib/src/option/empty_option.dart
@@ -22,10 +22,10 @@ abstract class EmptyOption extends Option<void> {
   void get value => {};
 }
 
-class IfNoneMatchOption extends EmptyOption implements OscoreOptionClassE {
+class IfNoneMatchOption extends EmptyOption with OscoreOptionClassE {
   IfNoneMatchOption() : super(OptionType.ifNoneMatch);
 }
 
-class EdhocOption extends EmptyOption implements OscoreOptionClassU {
+class EdhocOption extends EmptyOption with OscoreOptionClassU {
   EdhocOption() : super(OptionType.edhoc);
 }

--- a/lib/src/option/integer_option.dart
+++ b/lib/src/option/integer_option.dart
@@ -111,7 +111,7 @@ abstract class IntegerOption extends Option<int> {
   bool get isDefault => value == type.defaultValue;
 }
 
-class ContentFormatOption extends IntegerOption implements OscoreOptionClassE {
+class ContentFormatOption extends IntegerOption with OscoreOptionClassE {
   ContentFormatOption(final int value) : super(OptionType.contentFormat, value);
 
   ContentFormatOption.parse(final Uint8Buffer bytes)
@@ -152,7 +152,7 @@ enum ObserveRegistration {
 ///
 /// [RFC 7641, section 2]: https://www.rfc-editor.org/rfc/rfc7641#section-2
 class ObserveOption extends IntegerOption
-    implements OscoreOptionClassE, OscoreOptionClassU {
+    with OscoreOptionClassE, OscoreOptionClassU {
   ObserveOption(final int value) : super(OptionType.observe, value);
 
   ObserveOption.parse(final Uint8Buffer bytes)
@@ -172,7 +172,7 @@ class ObserveOption extends IntegerOption
       ObserveRegistration.parse(value);
 }
 
-class UriPortOption extends IntegerOption implements OscoreOptionClassU {
+class UriPortOption extends IntegerOption with OscoreOptionClassU {
   UriPortOption(final int value) : super(OptionType.uriPort, value);
 
   UriPortOption.parse(final Uint8Buffer bytes)
@@ -180,21 +180,21 @@ class UriPortOption extends IntegerOption implements OscoreOptionClassU {
 }
 
 class MaxAgeOption extends IntegerOption
-    implements OscoreOptionClassE, OscoreOptionClassU {
+    with OscoreOptionClassE, OscoreOptionClassU {
   MaxAgeOption(final int value) : super(OptionType.maxAge, value);
 
   MaxAgeOption.parse(final Uint8Buffer bytes)
       : super.parse(OptionType.maxAge, bytes);
 }
 
-class HopLimitOption extends IntegerOption implements OscoreOptionClassE {
+class HopLimitOption extends IntegerOption with OscoreOptionClassE {
   HopLimitOption(final int value) : super(OptionType.hopLimit, value);
 
   HopLimitOption.parse(final Uint8Buffer bytes)
       : super.parse(OptionType.hopLimit, bytes);
 }
 
-class AcceptOption extends IntegerOption implements OscoreOptionClassE {
+class AcceptOption extends IntegerOption with OscoreOptionClassE {
   AcceptOption(final int value) : super(OptionType.accept, value);
 
   AcceptOption.parse(final Uint8Buffer bytes)
@@ -202,7 +202,7 @@ class AcceptOption extends IntegerOption implements OscoreOptionClassE {
 }
 
 class Size2Option extends IntegerOption
-    implements OscoreOptionClassE, OscoreOptionClassU {
+    with OscoreOptionClassE, OscoreOptionClassU {
   Size2Option(final int value) : super(OptionType.size2, value);
 
   Size2Option.parse(final Uint8Buffer bytes)
@@ -210,7 +210,7 @@ class Size2Option extends IntegerOption
 }
 
 class Size1Option extends IntegerOption
-    implements OscoreOptionClassE, OscoreOptionClassU {
+    with OscoreOptionClassE, OscoreOptionClassU {
   Size1Option(final int value) : super(OptionType.size1, value);
 
   Size1Option.parse(final Uint8Buffer bytes)
@@ -225,7 +225,7 @@ class NoResponseOption extends IntegerOption {
 }
 
 class OcfAcceptContentFormatVersion extends IntegerOption
-    implements OscoreOptionClassE {
+    with OscoreOptionClassE {
   OcfAcceptContentFormatVersion(final int value)
       : super(OptionType.ocfAcceptContentFormatVersion, value);
 
@@ -233,8 +233,7 @@ class OcfAcceptContentFormatVersion extends IntegerOption
       : super.parse(OptionType.ocfAcceptContentFormatVersion, bytes);
 }
 
-class OcfContentFormatVersion extends IntegerOption
-    implements OscoreOptionClassE {
+class OcfContentFormatVersion extends IntegerOption with OscoreOptionClassE {
   OcfContentFormatVersion(final int value)
       : super(OptionType.ocfContentFormatVersion, value);
 

--- a/lib/src/option/opaque_option.dart
+++ b/lib/src/option/opaque_option.dart
@@ -23,11 +23,11 @@ abstract class OpaqueOption extends Option<Uint8Buffer> {
   String get valueString => hex.encode(byteValue.toList());
 }
 
-class IfMatchOption extends OpaqueOption implements OscoreOptionClassE {
+class IfMatchOption extends OpaqueOption with OscoreOptionClassE {
   IfMatchOption(final Uint8Buffer value) : super(OptionType.ifMatch, value);
 }
 
-class ETagOption extends OpaqueOption implements OscoreOptionClassE {
+class ETagOption extends OpaqueOption with OscoreOptionClassE {
   ETagOption(final Uint8Buffer value) : super(OptionType.eTag, value);
 }
 
@@ -38,7 +38,7 @@ class ETagOption extends OpaqueOption implements OscoreOptionClassE {
 ///
 /// [RFC 9175, section 2.2.1]: https://datatracker.ietf.org/doc/html/rfc9175#section-2.2.1
 class EchoOption extends OpaqueOption
-    implements OscoreOptionClassE, OscoreOptionClassU {
+    with OscoreOptionClassE, OscoreOptionClassU {
   EchoOption(final Uint8Buffer value) : super(OptionType.echo, value);
 }
 
@@ -50,7 +50,7 @@ class EchoOption extends OpaqueOption
 ///
 /// [RFC 9175, section 3.2.1]: https://datatracker.ietf.org/doc/html/rfc9175#section-3.2.1
 class RequestTagOption extends OpaqueOption
-    implements OscoreOptionClassE, OscoreOptionClassU {
+    with OscoreOptionClassE, OscoreOptionClassU {
   RequestTagOption(final Uint8Buffer value)
       : super(OptionType.requestTag, value);
 }

--- a/lib/src/option/option.dart
+++ b/lib/src/option/option.dart
@@ -87,7 +87,7 @@ abstract class Option<T> {
   bool get valid => length >= type.minLength && length <= type.maxLength;
 }
 
-/// Interface for an Oscore class E option (encrypted and integrity protected).
+/// Mixin for an Oscore class E option (encrypted and integrity protected).
 /// See [RFC 8613, section 4.1.1].
 ///
 /// Also applies to all options that are unknown or or for which OSCORE
@@ -96,9 +96,7 @@ abstract class Option<T> {
 /// [RFC 8613, section 4.1.1]: https://www.rfc-editor.org/rfc/rfc8613.html#section-4.1.1
 /// [RFC 8613, section 4.1]: https://www.rfc-editor.org/rfc/rfc8613.html#section-4.1
 /// https://www.rfc-editor.org/rfc/rfc8613.html#section-4.1
-abstract class OscoreOptionClassE {
-  OscoreOptionClassE._();
-}
+mixin OscoreOptionClassE {}
 
 /// Interface for an Oscore class I option (integrity protected only). See
 /// [RFC 8613, section 4.1.2].
@@ -107,17 +105,13 @@ abstract class OscoreOptionClassE {
 /// operations.
 ///
 /// [RFC 8613, section 4.1.2]: https://www.rfc-editor.org/rfc/rfc8613.html#section-4.1.2
-abstract class OscoreOptionClassI {
-  OscoreOptionClassI._();
-}
+mixin OscoreOptionClassI {}
 
-/// Interface for an Oscore class U option (unprotected). See
+/// Mixin for an Oscore class U option (unprotected). See
 /// [RFC 8613, section 4.1.2].
 ///
 /// Outer option message fields (Class U or I) are used to support proxy
 /// operations.
 ///
 /// [RFC 8613, section 4.1.2]: https://www.rfc-editor.org/rfc/rfc8613.html#section-4.1.2
-abstract class OscoreOptionClassU {
-  OscoreOptionClassU._();
-}
+mixin OscoreOptionClassU {}

--- a/lib/src/option/oscore_option.dart
+++ b/lib/src/option/oscore_option.dart
@@ -156,8 +156,7 @@ class OscoreOptionValue {
   final Uint8Buffer? kidContext;
 }
 
-class OscoreOption extends Option<OscoreOptionValue>
-    implements OscoreOptionClassU {
+class OscoreOption extends Option<OscoreOptionValue> with OscoreOptionClassU {
   OscoreOption(this.value);
 
   OscoreOption.parse(final Uint8Buffer bytes)

--- a/lib/src/option/string_option.dart
+++ b/lib/src/option/string_option.dart
@@ -59,7 +59,7 @@ abstract class PathOption extends StringOption {
   String get pathSegment => "/${value.replaceAll('/', '%2F')}";
 }
 
-class LocationPathOption extends PathOption implements OscoreOptionClassE {
+class LocationPathOption extends PathOption with OscoreOptionClassE {
   LocationPathOption(final String value)
       : super(OptionType.locationPath, value);
 
@@ -67,28 +67,28 @@ class LocationPathOption extends PathOption implements OscoreOptionClassE {
       : super.parse(OptionType.locationPath, bytes);
 }
 
-class UriHostOption extends StringOption implements OscoreOptionClassU {
+class UriHostOption extends StringOption with OscoreOptionClassU {
   UriHostOption(final String value) : super(OptionType.uriHost, value);
 
   UriHostOption.parse(final Uint8Buffer bytes)
       : super.parse(OptionType.uriHost, bytes);
 }
 
-class UriPathOption extends PathOption implements OscoreOptionClassE {
+class UriPathOption extends PathOption with OscoreOptionClassE {
   UriPathOption(final String value) : super(OptionType.uriPath, value);
 
   UriPathOption.parse(final Uint8Buffer bytes)
       : super.parse(OptionType.uriPath, bytes);
 }
 
-class UriQueryOption extends QueryOption implements OscoreOptionClassE {
+class UriQueryOption extends QueryOption with OscoreOptionClassE {
   UriQueryOption(final String value) : super(OptionType.uriQuery, value);
 
   UriQueryOption.parse(final Uint8Buffer bytes)
       : super.parse(OptionType.uriQuery, bytes);
 }
 
-class LocationQueryOption extends QueryOption implements OscoreOptionClassE {
+class LocationQueryOption extends QueryOption with OscoreOptionClassE {
   LocationQueryOption(final String value)
       : super(OptionType.locationQuery, value);
 
@@ -96,14 +96,14 @@ class LocationQueryOption extends QueryOption implements OscoreOptionClassE {
       : super.parse(OptionType.locationQuery, bytes);
 }
 
-class ProxyUriOption extends StringOption implements OscoreOptionClassU {
+class ProxyUriOption extends StringOption with OscoreOptionClassU {
   ProxyUriOption(final String value) : super(OptionType.proxyUri, value);
 
   ProxyUriOption.parse(final Uint8Buffer bytes)
       : super.parse(OptionType.proxyUri, bytes);
 }
 
-class ProxySchemeOption extends StringOption implements OscoreOptionClassU {
+class ProxySchemeOption extends StringOption with OscoreOptionClassU {
   ProxySchemeOption(final String value) : super(OptionType.proxyUri, value);
 
   ProxySchemeOption.parse(final Uint8Buffer bytes)


### PR DESCRIPTION
This PR proposes a trivial refactoring, turning the interfaces for identifying OSCORE class into more idiomatic Mixins.