### PR TITLE
feat!: rework URI handling for CoAP requests and responses

### DIFF
--- a/example/cancel_request.dart
+++ b/example/cancel_request.dart
@@ -18,7 +18,7 @@ FutureOr<void> main() async {
   final uri = Uri(scheme: 'coap', host: 'coap.me', port: conf.defaultPort);
   final client = CoapClient(uri, config: conf);
 
-  final cancelThisReq = CoapRequest.newGet()..uriPath = 'doesNotExist';
+  final cancelThisReq = CoapRequest.newGet(uri.replace(path: 'doesNotExist'));
 
   try {
     // Ensure this request is not also cancelled

--- a/example/get_max_retransmit.dart
+++ b/example/get_max_retransmit.dart
@@ -20,7 +20,7 @@ FutureOr<void> main() async {
 
   print('maxRetransmit config: ${conf.maxRetransmit}');
 
-  final request = CoapRequest.newGet()..uriPath = 'doesNotExist';
+  final request = CoapRequest.newGet(uri.replace(path: 'doesNotExist'));
   print('maxRetransmit request: ${request.maxRetransmit} (0=config default)');
 
   try {

--- a/example/get_observe_async.dart
+++ b/example/get_observe_async.dart
@@ -23,7 +23,7 @@ FutureOr<void> main() async {
   final client = CoapClient(uri, config: conf);
 
   // Create the request for the get request
-  final reqObs = CoapRequest.newGet()..uriPath = 'obs';
+  final reqObs = CoapRequest.newGet(uri.replace(path: 'obs'));
 
   try {
     print('Observing /obs on ${uri.host}');
@@ -32,8 +32,11 @@ FutureOr<void> main() async {
       print('/obs response: ${e.payloadString}');
     });
 
-    final reqObsNon = CoapRequest(RequestMethod.get, confirmable: false)
-      ..uriPath = 'obs-non';
+    final reqObsNon = CoapRequest(
+      uri.replace(path: 'obs-non'),
+      RequestMethod.get,
+      confirmable: false,
+    );
 
     print('Observing /obs-non on ${uri.host}');
     final obsNon = await client.observe(reqObsNon);

--- a/example/get_resource_multicast.dart
+++ b/example/get_resource_multicast.dart
@@ -21,7 +21,7 @@ FutureOr<void> main() async {
   final client = CoapClient(uri);
 
   try {
-    final request = CoapRequest.newGet()..uriPath = '/.well-known/core';
+    final request = CoapRequest.newGet(uri.replace(path: '/.well-known/core'));
 
     await for (final response in client.sendMulticast(request)) {
       print(response.payloadString);

--- a/example/post_resource.dart
+++ b/example/post_resource.dart
@@ -30,10 +30,12 @@ FutureOr<void> main() async {
       payload: 'SJHTestPost',
     );
     print('/large-create response status: ${response.statusCodeString}');
+    final resourceLocationPath = response.location.path;
+    print('Resource created under $resourceLocationPath');
 
-    print('Sending get /large-create to ${uri.host}');
-    response = await client.get('large-create');
-    print('/large-create response: ${response.payloadString}');
+    print('Sending get $resourceLocationPath to ${uri.host}');
+    response = await client.get(resourceLocationPath);
+    print('$resourceLocationPath response: ${response.payloadString}');
     print('E-Tags : ${response.etags.join(',')}');
   } on Exception catch (e) {
     print('CoAP encountered an exception: $e');

--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -126,7 +126,7 @@ class CoapClient {
 
   /// Performs a CoAP ping.
   Future<bool> ping() async {
-    final request = CoapRequest(RequestMethod.empty)
+    final request = CoapRequest(uri, RequestMethod.empty)
       ..token = CoapConstants.emptyToken;
     await _prepare(request);
     _endpoint!.sendEpRequest(request);
@@ -144,7 +144,8 @@ class CoapClient {
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request = CoapRequest.newGet(confirmable: confirmable);
+    final request =
+        CoapRequest.newGet(uri.replace(path: path), confirmable: confirmable);
     _build(
       request,
       path,
@@ -168,8 +169,9 @@ class CoapClient {
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request = CoapRequest.newPost(confirmable: confirmable)
-      ..setPayloadMedia(payload, format);
+    final request =
+        CoapRequest.newPost(uri.replace(path: path), confirmable: confirmable)
+          ..setPayloadMedia(payload, format);
     _build(
       request,
       path,
@@ -193,8 +195,9 @@ class CoapClient {
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request = CoapRequest.newPost(confirmable: confirmable)
-      ..setPayloadMediaRaw(payload, format);
+    final request =
+        CoapRequest.newPost(uri.replace(path: path), confirmable: confirmable)
+          ..setPayloadMediaRaw(payload, format);
     _build(
       request,
       path,
@@ -220,8 +223,9 @@ class CoapClient {
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request = CoapRequest.newPut(confirmable: confirmable)
-      ..setPayloadMedia(payload, format);
+    final request =
+        CoapRequest.newPut(uri.replace(path: path), confirmable: confirmable)
+          ..setPayloadMedia(payload, format);
     _build(
       request,
       path,
@@ -249,8 +253,9 @@ class CoapClient {
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request = CoapRequest.newPut(confirmable: confirmable)
-      ..setPayloadMediaRaw(payload, format);
+    final request =
+        CoapRequest.newPut(uri.replace(path: path), confirmable: confirmable)
+          ..setPayloadMediaRaw(payload, format);
     _build(
       request,
       path,
@@ -274,7 +279,10 @@ class CoapClient {
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request = CoapRequest.newDelete(confirmable: confirmable);
+    final request = CoapRequest.newDelete(
+      uri.replace(path: path),
+      confirmable: confirmable,
+    );
     _build(
       request,
       path,
@@ -300,7 +308,8 @@ class CoapClient {
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request = CoapRequest.newFetch(confirmable: confirmable);
+    final request =
+        CoapRequest.newFetch(uri.replace(path: path), confirmable: confirmable);
     _build(
       request,
       path,
@@ -330,8 +339,9 @@ class CoapClient {
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request = CoapRequest.newPatch(confirmable: confirmable)
-      ..setPayloadMedia(payload, format);
+    final request =
+        CoapRequest.newPatch(uri.replace(path: path), confirmable: confirmable)
+          ..setPayloadMedia(payload, format);
     _build(
       request,
       path,
@@ -363,8 +373,9 @@ class CoapClient {
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request = CoapRequest.newPatch(confirmable: confirmable)
-      ..setPayloadMediaRaw(payload, format);
+    final request =
+        CoapRequest.newPatch(uri.replace(path: path), confirmable: confirmable)
+          ..setPayloadMediaRaw(payload, format);
     _build(
       request,
       path,
@@ -396,8 +407,9 @@ class CoapClient {
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request = CoapRequest.newIPatch(confirmable: confirmable)
-      ..setPayloadMedia(payload, format);
+    final request =
+        CoapRequest.newIPatch(uri.replace(path: path), confirmable: confirmable)
+          ..setPayloadMedia(payload, format);
     _build(
       request,
       path,
@@ -429,8 +441,9 @@ class CoapClient {
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request = CoapRequest.newIPatch(confirmable: confirmable)
-      ..setPayloadMediaRaw(payload, format);
+    final request =
+        CoapRequest.newIPatch(uri.replace(path: path), confirmable: confirmable)
+          ..setPayloadMediaRaw(payload, format);
     _build(
       request,
       path,
@@ -465,11 +478,12 @@ class CoapClient {
   Future<Iterable<CoapWebLink>?> discover({
     final String query = '',
   }) async {
-    final discover = CoapRequest.newGet()
-      ..uriPath = CoapConstants.defaultWellKnownURI;
-    if (query.isNotEmpty) {
-      discover.uriQuery = query;
-    }
+    final discover = CoapRequest.newGet(
+      uri.replace(
+        path: CoapConstants.defaultWellKnownURI,
+        query: query,
+      ),
+    );
     final links = await send(discover);
     if (links.contentFormat != CoapMediaType.applicationLinkFormat) {
       return <CoapWebLink>[CoapWebLink('')];
@@ -563,7 +577,6 @@ class CoapClient {
     final List<Uint8Buffer>? etags,
   }) {
     request
-      ..uriPath = path
       ..accept = accept
       ..maxRetransmit = maxRetransmit;
     if (options != null) {
@@ -589,7 +602,6 @@ class CoapClient {
 
   Future<void> _prepare(final CoapRequest request) async {
     request
-      ..uri = uri
       ..timestamp = DateTime.now()
       ..eventBus = _eventBus;
 

--- a/lib/src/coap_message.dart
+++ b/lib/src/coap_message.dart
@@ -634,11 +634,23 @@ abstract class CoapMessage {
     return '\n${elements.join(',\n')}\n';
   }
 
-  /// Serializes this CoAP message from the UDP message format.
+  /// Generates a new CoAP message from [data] in the UDP message format.
   ///
-  /// Is also used for DTLS.
-  static CoapMessage? fromUdpPayload(final Uint8Buffer data) =>
-      deserializeUdpMessage(data);
+  /// The [scheme] can contain the value `coap` or `coaps` and will be used
+  /// in the `uri` field of CoAP request objects.
+  ///
+  /// The [destinationAddress] might be used when setting the URI for an
+  /// incoming CoAP request that does not contain an Uri-Host option.
+  static CoapMessage? fromUdpPayload(
+    final Uint8Buffer data,
+    final String scheme, {
+    final InternetAddress? destinationAddress,
+  }) =>
+      deserializeUdpMessage(
+        data,
+        scheme,
+        destinationAddress: destinationAddress,
+      );
 
   /// Serializes this CoAP message into the UDP message format.
   ///

--- a/lib/src/coap_observe_client_relation.dart
+++ b/lib/src/coap_observe_client_relation.dart
@@ -67,7 +67,7 @@ class CoapObserveClientRelation extends Stream<CoapResponse> {
 
   /// Create a cancellation request
   @internal
-  CoapRequest newCancel() => CoapRequest.newGet()
+  CoapRequest newCancel() => CoapRequest.newGet(_request.uri)
     // Copy options, but set Observe to cancel
     ..setOptions(_request.getAllOptions())
     ..observe = ObserveRegistration.deregister.value

--- a/lib/src/coap_request.dart
+++ b/lib/src/coap_request.dart
@@ -5,19 +5,15 @@
  * Copyright :  S.Hamblett
  */
 
-import 'dart:io';
-
 import 'package:meta/meta.dart';
 import 'package:typed_data/typed_buffers.dart';
 
 import 'coap_code.dart';
-import 'coap_constants.dart';
 import 'coap_message.dart';
 import 'coap_message_type.dart';
 import 'net/endpoint.dart';
-import 'option/integer_option.dart';
 import 'option/option.dart';
-import 'option/string_option.dart';
+import 'option/uri_converters.dart';
 
 /// This class describes the functionality of a CoAP Request as
 /// a subclass of a CoAP Message. It provides:
@@ -27,7 +23,7 @@ import 'option/string_option.dart';
 class CoapRequest extends CoapMessage {
   /// Initializes a request message.
   /// Defaults to confirmable
-  CoapRequest(this.method, {final bool confirmable = true})
+  CoapRequest(this.uri, this.method, {final bool confirmable = true})
       : super(
           method.coapCode,
           confirmable ? CoapMessageType.con : CoapMessageType.non,
@@ -48,8 +44,6 @@ class CoapRequest extends CoapMessage {
   /// Indicates whether this request is a multicast request or not.
   bool get isMulticast => destination?.isMulticast ?? false;
 
-  String? scheme = 'coap';
-
   /// Specifies the target resource of a request to a CoAP origin server.
   ///
   /// Composed from the Uri-Host, Uri-Port, Uri-Path, and Uri-Query Options.
@@ -57,145 +51,11 @@ class CoapRequest extends CoapMessage {
   /// See [RFC 7252, Section 5.10.1] for more information.
   ///
   /// [RFC 7252, Section 5.10.1]: https://www.rfc-editor.org/rfc/rfc7252#section-5.10.1
-  Uri get uri {
-    final host = getFirstOption<UriHostOption>()?.value ?? destination?.address;
-    final path = getOptions<UriPathOption>()
-        .map((final option) => option.pathSegment)
-        .join();
-    final queryParameters = Map.fromEntries(
-      getOptions<UriQueryOption>().map((final option) => option.queryParameter),
-    );
+  final Uri uri;
 
-    final optionPort = getFirstOption<UriPortOption>()?.value;
-
-    final int? port;
-    if (!(optionPort == CoapConstants.defaultPort &&
-            scheme == CoapConstants.uriScheme) &&
-        !(optionPort == CoapConstants.defaultSecurePort &&
-            scheme == CoapConstants.secureUriScheme)) {
-      port = optionPort;
-    } else {
-      port = null;
-    }
-
-    return Uri(
-      scheme: scheme,
-      host: host,
-      port: port,
-      path: path.isNotEmpty ? path : '/',
-      queryParameters: queryParameters.isNotEmpty ? queryParameters : null,
-    );
-  }
-
-  @internal
-  set uri(final Uri value) {
-    final host = value.host;
-    var port = value.port;
-    final query = value.query;
-    final path = value.path;
-    if (host.isNotEmpty && InternetAddress.tryParse(host) == null) {
-      uriHost = host;
-    }
-    if (port <= 0) {
-      if (value.scheme.isNotEmpty || value.scheme == CoapConstants.uriScheme) {
-        port = CoapConstants.defaultPort;
-      } else if (value.scheme == CoapConstants.secureUriScheme) {
-        port = CoapConstants.defaultSecurePort;
-      }
-    }
-    uriPort = port;
-    if (path.isNotEmpty) {
-      uriPath = path;
-    }
-    if (query.isNotEmpty) {
-      uriQuery = value.query;
-    }
-    scheme = value.scheme;
-  }
-
-  /// Uri's
-  String get uriHost => uri.host;
-
-  @internal
-  set uriHost(final String value) {
-    setOption(UriHostOption(value));
-  }
-
-  /// URI path
-  String get uriPath => uri.path;
-
-  /// Sets a number of Uri path options from a string
-  set uriPath(final String fullPath) {
-    clearUriPath();
-
-    var trimmedPath = fullPath;
-
-    if (fullPath.startsWith('/')) {
-      trimmedPath = fullPath.substring(1);
-    }
-
-    if (trimmedPath.isEmpty) {
-      return;
-    }
-
-    trimmedPath.split('/').forEach(addUriPath);
-  }
-
-  /// URI paths
-  List<UriPathOption> get uriPaths => getOptions<UriPathOption>();
-
-  /// Add a URI path
-  void addUriPath(final String path) => addOption(UriPathOption(path));
-
-  /// Remove a URI path
-  void removeUriPath(final String path) {
-    removeOptionWhere(
-      (final element) => element is UriPathOption && element.value == path,
-    );
-  }
-
-  /// Clear URI paths
-  void clearUriPath() => removeOptions<UriPathOption>();
-
-  /// URI query
-  String get uriQuery => uri.query;
-
-  /// Set a URI query
-  set uriQuery(final String fullQuery) {
-    var trimmedQuery = fullQuery;
-    if (trimmedQuery.startsWith('?')) {
-      trimmedQuery = trimmedQuery.substring(1);
-    }
-    clearUriQuery();
-    trimmedQuery.split('&').forEach(addUriQuery);
-  }
-
-  /// URI queries
-  List<UriQueryOption> get uriQueries => getOptions<UriQueryOption>();
-
-  /// Add a URI query
-  void addUriQuery(final String query) => addOption(UriQueryOption(query));
-
-  /// Remove a URI query
-  void removeUriQuery(final String query) {
-    removeOptionWhere(
-      (final element) => element is UriQueryOption && element.value == query,
-    );
-  }
-
-  /// Clear URI queries
-  void clearUriQuery() => removeOptions<UriQueryOption>();
-
-  /// Uri port
-  int get uriPort => uri.port;
-
-  set uriPort(final int value) {
-    if (value == 0) {
-      removeOptions<UriPortOption>();
-    } else {
-      addOption(UriPortOption(value));
-    }
-  }
+  @override
+  List<Option<Object?>> getAllOptions() =>
+      uriToOptions(uri, destination)..addAll(super.getAllOptions());
 
   Endpoint? _endpoint;
 
@@ -213,34 +73,47 @@ class CoapRequest extends CoapMessage {
   String toString() => '\n<<< Request Message >>>${super.toString()}';
 
   /// Construct a GET request.
-  factory CoapRequest.newGet({final bool confirmable = true}) =>
-      CoapRequest(RequestMethod.get, confirmable: confirmable);
+  factory CoapRequest.newGet(final Uri uri, {final bool confirmable = true}) =>
+      CoapRequest(uri, RequestMethod.get, confirmable: confirmable);
 
   /// Construct a POST request.
-  factory CoapRequest.newPost({final bool confirmable = true}) =>
-      CoapRequest(RequestMethod.post, confirmable: confirmable);
+  factory CoapRequest.newPost(final Uri uri, {final bool confirmable = true}) =>
+      CoapRequest(uri, RequestMethod.post, confirmable: confirmable);
 
   /// Construct a PUT request.
-  factory CoapRequest.newPut({final bool confirmable = true}) =>
-      CoapRequest(RequestMethod.put, confirmable: confirmable);
+  factory CoapRequest.newPut(final Uri uri, {final bool confirmable = true}) =>
+      CoapRequest(uri, RequestMethod.put, confirmable: confirmable);
 
   /// Construct a DELETE request.
-  factory CoapRequest.newDelete({final bool confirmable = true}) =>
-      CoapRequest(RequestMethod.delete, confirmable: confirmable);
+  factory CoapRequest.newDelete(
+    final Uri uri, {
+    final bool confirmable = true,
+  }) =>
+      CoapRequest(uri, RequestMethod.delete, confirmable: confirmable);
 
   /// Construct a FETCH request.
-  factory CoapRequest.newFetch({final bool confirmable = true}) =>
-      CoapRequest(RequestMethod.fetch, confirmable: confirmable);
+  factory CoapRequest.newFetch(
+    final Uri uri, {
+    final bool confirmable = true,
+  }) =>
+      CoapRequest(uri, RequestMethod.fetch, confirmable: confirmable);
 
   /// Construct a PATCH request.
-  factory CoapRequest.newPatch({final bool confirmable = true}) =>
-      CoapRequest(RequestMethod.patch, confirmable: confirmable);
+  factory CoapRequest.newPatch(
+    final Uri uri, {
+    final bool confirmable = true,
+  }) =>
+      CoapRequest(uri, RequestMethod.patch, confirmable: confirmable);
 
   /// Construct a iPATCH request.
-  factory CoapRequest.newIPatch({final bool confirmable = true}) =>
-      CoapRequest(RequestMethod.ipatch, confirmable: confirmable);
+  factory CoapRequest.newIPatch(
+    final Uri uri, {
+    final bool confirmable = true,
+  }) =>
+      CoapRequest(uri, RequestMethod.ipatch, confirmable: confirmable);
 
   CoapRequest.fromParsed(
+    this.uri,
     this.method, {
     required final CoapMessageType type,
     required final int id,

--- a/lib/src/coap_response.dart
+++ b/lib/src/coap_response.dart
@@ -13,17 +13,37 @@ import 'coap_message.dart';
 import 'coap_message_type.dart';
 import 'coap_request.dart';
 import 'option/option.dart';
-import 'option/string_option.dart';
+import 'option/uri_converters.dart';
 
 /// Represents a CoAP response to a CoAP request.
 /// A response is either a piggy-backed response with type ACK
 /// or a separate response with type CON or NON.
 class CoapResponse extends CoapMessage {
   /// Initializes a response message.
-  CoapResponse(this.responseCode, final CoapMessageType type)
-      : super(responseCode.coapCode, type);
+  CoapResponse(
+    this.responseCode,
+    final CoapMessageType type, {
+    final Uri? location,
+  })  : location = location ?? Uri(path: '/'),
+        super(responseCode.coapCode, type);
 
   final ResponseCode responseCode;
+
+  /// Relative [Uri] that consists either of an absolute path, a query string,
+  /// or both.
+  ///
+  /// May be included in a 2.01 (Created) response to indicate the location of
+  /// the resource created as the result of a POST request (see
+  /// [RFC 7252, Section 5.8.2]).
+  ///
+  /// The location is supposed to be resolved relative to the request URI.
+  ///
+  /// [RFC 7252, Section 5.8.2]: https://www.rfc-editor.org/rfc/rfc7252#section-5.8.2
+  final Uri location;
+
+  @override
+  List<Option<Object?>> getAllOptions() =>
+      locationToOptions(location)..addAll(super.getAllOptions());
 
   /// Status code as a string
   String get statusCodeString => code.toString();
@@ -64,9 +84,10 @@ class CoapResponse extends CoapMessage {
   factory CoapResponse.createResponse(
     final CoapRequest request,
     final ResponseCode statusCode,
-    final CoapMessageType type,
-  ) =>
-      CoapResponse(statusCode, type)
+    final CoapMessageType type, {
+    final Uri? location,
+  }) =>
+      CoapResponse(statusCode, type, location: location)
         ..destination = request.source
         ..token = request.token;
 
@@ -79,7 +100,9 @@ class CoapResponse extends CoapMessage {
     required final Uint8Buffer? payload,
     required final bool hasUnknownCriticalOption,
     required final bool hasFormatError,
-  }) : super.fromParsed(
+    final Uri? location,
+  })  : location = location ?? Uri(path: '/'),
+        super.fromParsed(
           responseCode.coapCode,
           type,
           id: id,
@@ -89,93 +112,4 @@ class CoapResponse extends CoapMessage {
           hasFormatError: hasFormatError,
           payload: payload,
         );
-
-  /// Relative [Uri] that consists either of an absolute path, a query string,
-  /// or both.
-  ///
-  /// May be included in a 2.01 (Created) response to indicate the location of
-  /// the resource created as the result of a POST request (see
-  /// [RFC 7252, Section 5.8.2]).
-  ///
-  /// The location is supposed to be resolved relative to the request URI.
-  ///
-  /// [RFC 7252, Section 5.8.2]: https://www.rfc-editor.org/rfc/rfc7252#section-5.8.2
-  Uri get location {
-    final path = getOptions<LocationPathOption>()
-        .map((final option) => option.pathSegment)
-        .join();
-    final queryParameters = Map.fromEntries(
-      getOptions<LocationQueryOption>().map(
-        (final option) => option.queryParameter,
-      ),
-    );
-
-    return Uri(
-      path: path.isNotEmpty ? path : '/',
-      queryParameters: queryParameters.isNotEmpty ? queryParameters : null,
-    );
-  }
-
-  /// Location path as a string
-  String get locationPath => location.path;
-
-  /// Set the location path from a string
-  set locationPath(final String fullPath) {
-    clearLocationPath();
-
-    var trimmedPath = fullPath;
-
-    if (fullPath.startsWith('/')) {
-      trimmedPath = fullPath.substring(1);
-    }
-
-    trimmedPath.split('/').forEach(addLocationPath);
-  }
-
-  /// Location paths
-  List<LocationPathOption> get locationPaths =>
-      getOptions<LocationPathOption>();
-
-  /// Add a location path
-  void addLocationPath(final String path) =>
-      addOption(LocationPathOption(path));
-
-  /// Remove a location path
-  void removelocationPath(final String path) =>
-      removeOptionWhere((final element) => element.value == path);
-
-  /// Clear location path
-  void clearLocationPath() => removeOptions<LocationPathOption>();
-
-  /// Location query
-  String get locationQuery => location.query;
-
-  /// Set a location query
-  set locationQuery(final String fullQuery) {
-    var trimmedQuery = fullQuery;
-    if (trimmedQuery.startsWith('?')) {
-      trimmedQuery = trimmedQuery.substring(1);
-    }
-    clearLocationQuery();
-    trimmedQuery.split('&').forEach(addLocationQuery);
-  }
-
-  /// Location queries
-  List<LocationQueryOption> get locationQueries =>
-      getOptions<LocationQueryOption>();
-
-  /// Add a location query
-  void addLocationQuery(final String query) =>
-      addOption(LocationQueryOption(query));
-
-  /// Remove a location query
-  void removeLocationQuery(final String query) {
-    removeOptionWhere(
-      (final element) =>
-          element is LocationQueryOption && element.value == query,
-    );
-  }
-
-  /// Clear location  queries
-  void clearLocationQuery() => removeOptions<LocationQueryOption>();
 }

--- a/lib/src/codec/udp/message_encoder.dart
+++ b/lib/src/codec/udp/message_encoder.dart
@@ -106,13 +106,14 @@ Uint8Buffer serializeUdpMessage(final CoapMessage message) {
 }
 
 bool _shouldBeSkipped(final Option<Object?> opt, final CoapMessage message) {
-  if (opt is UriHostOption &&
-      InternetAddress.tryParse(opt.value) == message.destination) {
-    return true;
+  if (opt is UriHostOption) {
+    final hostAddress = InternetAddress.tryParse(opt.value);
+
+    return hostAddress != null && hostAddress == message.destination;
   }
 
   if (opt is UriPortOption && message is CoapRequest) {
-    return _usesDefaultPort(message.scheme, opt.value);
+    return _usesDefaultPort(message.uri.scheme, opt.value);
   }
 
   return false;

--- a/lib/src/network/coap_network_openssl.dart
+++ b/lib/src/network/coap_network_openssl.dart
@@ -161,8 +161,10 @@ class CoapNetworkUDPOpenSSL extends CoapNetworkUDP {
   void _receive() {
     _dtlsConnection?.listen(
       (final datagram) {
-        final message =
-            CoapMessage.fromUdpPayload(Uint8Buffer()..addAll(datagram.data));
+        final message = CoapMessage.fromUdpPayload(
+          Uint8Buffer()..addAll(datagram.data),
+          'coaps',
+        );
         eventBus.fire(CoapMessageReceivedEvent(message, address));
       },
       onError: (final Object e, final StackTrace s) =>

--- a/lib/src/network/coap_network_udp.dart
+++ b/lib/src/network/coap_network_udp.dart
@@ -92,8 +92,10 @@ class CoapNetworkUDP implements CoapINetwork {
               return;
             }
             // d.address can differ from address with multicast
-            final message =
-                CoapMessage.fromUdpPayload(Uint8Buffer()..addAll(d.data));
+            final message = CoapMessage.fromUdpPayload(
+              Uint8Buffer()..addAll(d.data),
+              'coap',
+            );
             eventBus.fire(CoapMessageReceivedEvent(message, d.address));
             break;
           // When we manually closed the socket (no need to do anything)

--- a/lib/src/option/option.dart
+++ b/lib/src/option/option.dart
@@ -3,6 +3,8 @@ import 'package:meta/meta.dart';
 import 'package:typed_data/typed_data.dart';
 
 import 'coap_option_type.dart';
+import 'integer_option.dart';
+import 'string_option.dart';
 
 /// This class describes the options of the CoAP messages.
 @immutable
@@ -85,6 +87,15 @@ abstract class Option<T> {
   String toString() => '$name: $valueString';
 
   bool get valid => length >= type.minLength && length <= type.maxLength;
+
+  bool get isUriOption =>
+      this is UriHostOption ||
+      this is UriPathOption ||
+      this is UriPortOption ||
+      this is UriQueryOption;
+
+  bool get isLocationOption =>
+      this is LocationPathOption || this is LocationQueryOption;
 }
 
 /// Mixin for an Oscore class E option (encrypted and integrity protected).

--- a/lib/src/option/uri_converters.dart
+++ b/lib/src/option/uri_converters.dart
@@ -1,0 +1,222 @@
+// Copyright (c) 2023, the coap project authors.
+//
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'integer_option.dart';
+import 'option.dart';
+import 'string_option.dart';
+
+// TODO(JKRhb): Consider turning this into an enhanced enum.
+int? _defaultPortFromScheme(final String? scheme) {
+  switch (scheme) {
+    case 'coap':
+      return 5683;
+    case 'coaps':
+      return 5684;
+    case 'coap+tcp':
+      return 5683;
+    case 'coaps+tcp':
+      return 5684;
+    case 'coap+ws':
+      return 80;
+    case 'coaps+ws':
+      return 443;
+  }
+
+  return null;
+}
+
+bool _isSupportedUriScheme(final String scheme) => const [
+      'coap',
+      'coaps',
+      'coap+tcp',
+      'coaps+tcp',
+      'coap+ws',
+      'coaps+ws',
+    ].contains(scheme);
+
+/// Converts a list of [Option]s to a [Uri] of a provided [scheme] as specified
+/// in [RFC 7252, section 6.5].
+///
+/// If no [UriHostOption] is included in the [Option]s, the [destinationAddress]
+/// will be used for the host component.
+///
+/// [RFC 7252, section 6.5]: https://www.rfc-editor.org/rfc/rfc7252.html#section-6.5
+Uri optionsToUri(
+  final List<Option<Object?>> options, {
+  final String? scheme,
+  final InternetAddress? destinationAddress,
+}) {
+  var host = destinationAddress?.address;
+  int? port;
+  var path = '';
+  var query = '';
+
+  for (final option in options) {
+    if (option is UriHostOption) {
+      host = option.value;
+      continue;
+    }
+
+    if (option is UriPortOption) {
+      final optionValue = option.value;
+      if (_defaultPortFromScheme(scheme) != optionValue) {
+        port = optionValue;
+      }
+
+      continue;
+    }
+
+    if (option is PathOption) {
+      // TODO(JKRhb): Refactor?
+      final pathSegment = option.value.replaceAll('/', '%2F');
+      path = '$path/$pathSegment';
+      continue;
+    }
+
+    if (option is QueryOption) {
+      // TODO(JKRhb): Refactor?
+      final queryParameter = option.value.replaceAll('&', '%26');
+
+      if (query.isEmpty) {
+        query = queryParameter;
+        continue;
+      }
+
+      query = '$query&$queryParameter';
+    }
+  }
+
+  // Step 7 of the algorithm
+  if (path.isEmpty) {
+    path = '/';
+  }
+
+  return Uri(
+    scheme: scheme,
+    host: host,
+    port: port,
+    path: path,
+    query: query,
+  );
+}
+
+/// Converts a [uri] into a list of [Option]s as specified
+/// in [RFC 7252, section 6.4].
+///
+/// If the [uri]'s host component should equal the [destinationAddress], no
+/// [UriHostOption] will be included in the returned [List] of [Option]s.
+/// Similarly, if the default port for the provided URI scheme should be used,
+/// it will be omitted as an [Option].
+///
+/// [RFC 7252, section 6.4]: https://www.rfc-editor.org/rfc/rfc7252.html#section-6.4
+List<Option<Object?>> uriToOptions(
+  final Uri uri,
+  final InternetAddress? destinationAddress,
+) {
+  final options = <Option<Object?>>[];
+
+  if (!uri.isAbsolute) {
+    throw FormatException('Provided request URI $uri is not absolute.');
+  }
+
+  final scheme = uri.scheme;
+  if (!_isSupportedUriScheme(scheme)) {
+    throw FormatException(
+      'Provided request URI scheme $scheme is not allowed.',
+    );
+  }
+
+  if (uri.hasFragment) {
+    throw FormatException(
+      '$uri contains a URI fragment, which is not allowed',
+    );
+  }
+
+  final host = uri.host;
+  if (host != destinationAddress?.address) {
+    options.add(UriHostOption(host));
+  }
+
+  final port = uri.port;
+  final defaultPorts = [0, _defaultPortFromScheme(scheme)];
+  if (!defaultPorts.contains(port)) {
+    options.add(UriPortOption(port));
+  }
+
+  options
+    ..addAll(_uriPathsToOptions<UriPathOption>(uri))
+    ..addAll(_uriQueriesToOptions<UriQueryOption>(uri));
+
+  return options;
+}
+
+/// Converts a relative [location] URI into a list of [Option]s.
+List<Option<Object?>> locationToOptions(final Uri location) => [
+      ..._uriPathsToOptions<LocationPathOption>(location),
+      ..._uriQueriesToOptions<LocationQueryOption>(location)
+    ];
+
+/// Converts a [uri]'s path components into a list of [PathOption]s as specified
+/// in [RFC 7252, section 6.4].
+///
+/// [RFC 7252, section 6.4]: https://www.rfc-editor.org/rfc/rfc7252.html#section-6.4
+List<Option<Object?>> _uriPathsToOptions<T extends PathOption>(final Uri uri) {
+  final options = <Option<Object?>>[];
+
+  final path = uri.path;
+  if (path.isNotEmpty && path != '/') {
+    final optionValues = path.split('/').map(Uri.decodeFull);
+
+    for (final optionValue in optionValues.skip(1)) {
+      switch (T) {
+        case UriPathOption:
+          options.add(UriPathOption(optionValue));
+          continue;
+        case LocationPathOption:
+          options.add(LocationPathOption(optionValue));
+          continue;
+      }
+
+      throw ArgumentError('Specified invalid option type $T');
+    }
+  }
+
+  return options;
+}
+
+/// Converts a [uri]'s query parameters into a list of [QueryOption]s as
+/// specified in [RFC 7252, section 6.4].
+///
+/// [RFC 7252, section 6.4]: https://www.rfc-editor.org/rfc/rfc7252.html#section-6.4
+List<Option<Object?>> _uriQueriesToOptions<T extends QueryOption>(
+  final Uri uri,
+) {
+  final options = <Option<Object?>>[];
+
+  for (final queryParameter in uri.queryParameters.entries) {
+    final components = [queryParameter.key];
+    final value = queryParameter.value;
+
+    if (value.isNotEmpty) {
+      components.add(value);
+    }
+
+    final optionValue = components.map(Uri.decodeFull).join('=');
+
+    switch (T) {
+      case UriQueryOption:
+        options.add(UriQueryOption(optionValue));
+        continue;
+      case LocationQueryOption:
+        options.add(LocationQueryOption(optionValue));
+        continue;
+    }
+
+    throw ArgumentError('Specified invalid option type $T');
+  }
+
+  return options;
+}

--- a/lib/src/stack/layers/blockwise.dart
+++ b/lib/src/stack/layers/blockwise.dart
@@ -128,7 +128,7 @@ class BlockwiseLayer extends BaseLayer {
           _earlyBlock2Negotiation(exchange, request);
 
           // Assemble and deliver
-          final assembled = CoapRequest(request.method);
+          final assembled = CoapRequest(request.uri, request.method);
           _assembleMessage(status, assembled, request);
 
           exchange.request = assembled;
@@ -326,13 +326,12 @@ class BlockwiseLayer extends BaseLayer {
           final m = block2.m;
 
           final nextBlock = Block2Option.fromParts(num, szx, m: m);
-          final block = CoapRequest(request.method)
+          final block = CoapRequest(request.uri, request.method)
             ..endpoint = request.endpoint
             // NON could make sense over SMS or similar transports
             ..setOptions(request.getAllOptions())
             ..setOption(nextBlock)
-            ..destination = response.source
-            ..uriHost = response.source?.host ?? '';
+            ..destination = response.source;
           if (exchange is CoapMulticastExchange) {
             status = _copyBlockStatus(
               exchange.responseBlockStatus,
@@ -413,7 +412,7 @@ class BlockwiseLayer extends BaseLayer {
   ) {
     final num = status.currentNUM;
     final szx = status.currentSZX;
-    final block = CoapRequest(request.method)
+    final block = CoapRequest(request.uri, request.method)
       ..endpoint = request.endpoint
       ..setOptions(request.getAllOptions())
       ..destination = request.destination

--- a/lib/src/stack/layers/observe.dart
+++ b/lib/src/stack/layers/observe.dart
@@ -235,7 +235,7 @@ class _ReregistrationContext {
   void _timerElapsed() {
     final request = _exchange.request;
     if (!request.isCancelled) {
-      final refresh = CoapRequest.newGet()
+      final refresh = CoapRequest.newGet(request.uri)
         ..setOptions(request.getAllOptions())
         // Make sure Observe is set and zero
         ..observe = ObserveRegistration.register.value

--- a/test/coap_datagram_read_write_test.dart
+++ b/test/coap_datagram_read_write_test.dart
@@ -235,14 +235,15 @@ void main() {
         ..addAll(
           List<int>.generate(tokenLength, ((final index) => index % 256)),
         ));
-      final request = CoapRequest(RequestMethod.get)
-        ..id = 5
-        ..token = token;
+      final request =
+          CoapRequest(Uri.parse('coap://example.org'), RequestMethod.get)
+            ..id = 5
+            ..token = token;
 
       final payload = request.toUdpPayload();
       expect(
         leq.equals(
-          CoapMessage.fromUdpPayload(payload)?.token?.toList(),
+          CoapMessage.fromUdpPayload(payload, 'coap')?.token?.toList(),
           token,
         ),
         isTrue,


### PR DESCRIPTION
This PR proposes a rework of the `uri` field within the `CoapRequest` class. Before, the `Uri` was constructed by using individual `Uri-Host`, `Uri-Path`, `Uri-Port`, and `Uri-Query` options.

However, I noticed that a request's URI can be set in a much simpler way by simply turning it into a regular field which can then be converted into and from individual URI component options. This enabled me to implement the algorithms described in [section 6.4](https://www.rfc-editor.org/rfc/rfc7252.html#section-6.4) and [section 6.5 of RFC 7252](https://www.rfc-editor.org/rfc/rfc7252.html#section-6.5) in two functions, which makes debugging a bit easier. With these changes, the conversion should now be RFC-compliant (again) and slightly easier to maintain.

The new approach also allowed/incentivized me to make a slight (but breaking) API change, adding the URI as a request constructor parameter. Therefore, this PR can also be seen as an intermediate step towards #160, but also towards further API and type-safety improvements.

(CC @shamblett @JosefWN)