### PR TITLE
chore: let CI generate code coverage reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,5 @@ jobs:
       - name: Analyze project source
         run: dart analyze
 
-      - name: Run tests
-        run: dart test
+      - name: Run tests with coverage
+        run: dart run coverage:test_with_coverage

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ doc/api/
 .idea/
 .DS_Store
 .directory
+
+# Generated coverage reports
+coverage/


### PR DESCRIPTION
This PR adjusts the CI pipeline slightly so that it generates code coverage reports when testing. This would make it possible to visualize coverage of the code base using a provider such as codecov or coveralls in a next step.