### PR TITLE
feat: improve OCF version options API

### DIFF
--- a/lib/src/option/coap_option_type.dart
+++ b/lib/src/option/coap_option_type.dart
@@ -29,7 +29,7 @@ abstract class UnknownOptionException implements Exception {
   UnknownOptionException(this.optionNumber, this.errorMessage);
 
   @override
-  String toString() => '$runtimeType:  $errorMessage $optionNumber';
+  String toString() => '$runtimeType:  $errorMessage';
 }
 
 /// [Exception] that is thrown when an unknown elective CoapOption number is
@@ -302,7 +302,7 @@ enum OptionType implements Comparable<OptionType> {
       return optionType;
     }
 
-    const errorMessage = 'Uncountered an unknown option number';
+    final errorMessage = 'Uncountered an unknown option number $type';
 
     if (type.isOdd) {
       throw UnknownCriticalOptionException(type, errorMessage);

--- a/lib/src/option/integer_option.dart
+++ b/lib/src/option/integer_option.dart
@@ -249,19 +249,94 @@ class NoResponseOption extends IntegerOption {
       : super.parse(OptionType.noResponse, bytes);
 }
 
-class OcfAcceptContentFormatVersion extends IntegerOption
-    with OscoreOptionClassE {
+/// Base class for the OCF options [OcfAcceptContentFormatVersion] and
+/// [OcfContentFormatVersion].
+abstract class OcfVersionOption extends IntegerOption with OscoreOptionClassE {
+  OcfVersionOption(super.type, super.value);
+
+  OcfVersionOption.parse(super.type, super.bytes) : super.parse();
+
+  /// Creates a new OCF version option of a specified [type] composed of a
+  /// [majorVersion], a [minorVersion], and a [subVersion].
+  OcfVersionOption.fromVersion(
+    final OptionType type,
+    final int majorVersion,
+    final int minorVersion,
+    final int subVersion,
+  ) : super(type, _versionToValue(majorVersion, minorVersion, subVersion));
+
+  static int _versionToValue(
+    final int majorVersion,
+    final int minorVersion,
+    final int subVersion,
+  ) =>
+      (majorVersion << _majorBitShift) +
+      (minorVersion << _minorBitShift) +
+      subVersion;
+
+  static int _maskBits(final int maskLength) => (1 << maskLength) - 1;
+
+  static const _majorBitShift = 11;
+
+  static const _minorBitShift = 6;
+
+  /// The major version represented by the option [value].
+  ///
+  /// Represented by the five most significant bits.
+  int get majorVersion => (value >> _majorBitShift) & _maskBits(5);
+
+  /// The minor version represented by the option [value].
+  ///
+  /// Represented by bits 6 to 10.
+  int get minorVersion => (value >> _minorBitShift) & _maskBits(5);
+
+  /// The sub version represented by the option [value].
+  ///
+  /// Represented by the six least significant bits.
+  int get subVersion => value & _maskBits(6);
+
+  @override
+  String get valueString => '$majorVersion.$minorVersion.$subVersion';
+}
+
+class OcfAcceptContentFormatVersion extends OcfVersionOption {
   OcfAcceptContentFormatVersion(final int value)
       : super(OptionType.ocfAcceptContentFormatVersion, value);
 
   OcfAcceptContentFormatVersion.parse(final Uint8Buffer bytes)
       : super.parse(OptionType.ocfAcceptContentFormatVersion, bytes);
+
+  /// Creates a new [OcfAcceptContentFormatVersion] composed of a
+  /// [majorVersion], a [minorVersion], and a [subVersion].
+  OcfAcceptContentFormatVersion.fromVersion(
+    final int majorVersion,
+    final int minorVersion,
+    final int subVersion,
+  ) : super.fromVersion(
+          OptionType.ocfAcceptContentFormatVersion,
+          majorVersion,
+          minorVersion,
+          subVersion,
+        );
 }
 
-class OcfContentFormatVersion extends IntegerOption with OscoreOptionClassE {
+class OcfContentFormatVersion extends OcfVersionOption {
   OcfContentFormatVersion(final int value)
       : super(OptionType.ocfContentFormatVersion, value);
 
   OcfContentFormatVersion.parse(final Uint8Buffer bytes)
       : super.parse(OptionType.ocfContentFormatVersion, bytes);
+
+  /// Creates a new [OcfContentFormatVersion] composed of a [majorVersion], a
+  /// [minorVersion], and a [subVersion].
+  OcfContentFormatVersion.fromVersion(
+    final int majorVersion,
+    final int minorVersion,
+    final int subVersion,
+  ) : super.fromVersion(
+          OptionType.ocfContentFormatVersion,
+          majorVersion,
+          minorVersion,
+          subVersion,
+        );
 }

--- a/test/coap_option_test.dart
+++ b/test/coap_option_test.dart
@@ -122,6 +122,22 @@ void main() {
       expect(OptionType.uriHost.isSafe, false);
       expect(OptionType.ifMatch.isSafe, true);
     });
+
+    test('OCF Options', () {
+      final ocfContentFormatVersion =
+          OcfContentFormatVersion.fromVersion(10, 13, 2);
+      expect(ocfContentFormatVersion.valueString, '10.13.2');
+
+      final ocfAcceptContentFormatVersion =
+          OcfAcceptContentFormatVersion.fromVersion(1, 0, 0);
+      expect(ocfAcceptContentFormatVersion.valueString, '1.0.0');
+
+      expect(
+        // Option only has one byte but two bytes are required.
+        () => OcfAcceptContentFormatVersion.fromVersion(0, 0, 1),
+        throwsA(const TypeMatcher<UnknownCriticalOptionException>()),
+      );
+    });
   });
 
   group('Block Option', () {


### PR DESCRIPTION
I understood only recently how the two options specified by OCF are supposed to work. This PR updates the API for creating and reading out these options, adds some documentation, and fixes a minor issue in the `UnknownOptionException` class.