### PR TITLE
chore(ci): add codecov upload step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,11 @@ jobs:
 
       - name: Run tests with coverage
         run: dart run coverage:test_with_coverage
+
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: coverage/lcov.info
+          name: Upload to codecov.io
+          verbose: true

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![pub package](https://img.shields.io/pub/v/coap.svg)](https://pub.dev/packages/coap)
 [![Build Status](https://github.com/shamblett/coap/actions/workflows/ci.yml/badge.svg)](https://github.com/shamblett/coap/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/shamblett/coap/branch/main/graph/badge.svg)](https://codecov.io/gh/shamblett/coap)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![Build Status](https://github.com/shamblett/coap/actions/workflows/ci.yml/badge.svg)](https://github.com/shamblett/coap/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/shamblett/coap/branch/main/graph/badge.svg)](https://codecov.io/gh/shamblett/coap)
+
 # coap
 The Constrained Application Protocol is a RESTful web transfer protocol for resource-constrained networks and nodes.
 The CoAP library is an implementation in Dart providing a CoAP client, the code was initially a port from the C# .NET project [CoAP.NET](https://github.com/smeshlink/CoAP.NET).


### PR DESCRIPTION
As discussed in #171, this PR adds an upload step for codecov.io which enables code coverage visualization features. ~~For this to properly work, adding a `CODECOV_TOKEN` as a secret would also be needed, I think.~~

Using the [codecov GitHub app](https://github.com/marketplace/codecov), we could integrate code coverage report into PRs, which I quite like since they create an incentive to provide additional tests. Not everyone seems to be a fan of them, though.

Edit: Seems as if the bot is working already :)