### PR TITLE
chore!: update dtls2, update DTLS PSK API

### DIFF
--- a/example/get_resource_secure.dart
+++ b/example/get_resource_secure.dart
@@ -16,16 +16,15 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:typed_data';
 import 'package:coap/coap.dart';
 
-final identity = Uint8List.fromList(utf8.encode('Client_identity'));
-final preSharedKey = Uint8List.fromList(utf8.encode('secretPSK'));
+final identity = utf8.encode('Client_identity');
+final preSharedKey = utf8.encode('secretPSK');
 
 final pskCredentials =
     PskCredentials(identity: identity, preSharedKey: preSharedKey);
 
-PskCredentials pskCredentialsCallback(final Uint8List indentity) =>
+PskCredentials pskCredentialsCallback(final String? identityHint) =>
     pskCredentials;
 
 class DtlsConfig extends DefaultCoapConfig {

--- a/lib/src/network/credentials/psk_credentials.dart
+++ b/lib/src/network/credentials/psk_credentials.dart
@@ -14,15 +14,15 @@ import 'dart:typed_data';
 /// can probably be ignored in most cases, when both the identity and the key
 /// are known in advance.
 typedef PskCredentialsCallback = PskCredentials Function(
-  Uint8List identityHint,
+  String? identityHint,
 );
 
 /// Credentials used for PSK Cipher Suites consisting of an [identity]
 /// and a [preSharedKey].
 class PskCredentials {
-  Uint8List identity;
+  Iterable<int> identity;
 
-  Uint8List preSharedKey;
+  Iterable<int> preSharedKey;
 
   PskCredentials({required this.identity, required this.preSharedKey});
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   build: ^2.3.0
   collection: ^1.16.0
   convert: ^3.0.2
-  dtls2: ^0.11.0
+  dtls2: ^0.12.0
   event_bus: ^2.0.0
   meta: ^1.8.0
   path: ^1.8.2


### PR DESCRIPTION
This PR updates the `dtls2` dependency and incorporates some (unfortunately breaking) API changes.