### PR TITLE
Improve request APIs

### DIFF
--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -183,7 +183,9 @@ class CoapClient {
       ),
       confirmable: confirmable,
       accept: accept,
-    )..setPayloadMedia(payload, format);
+      contentFormat: format,
+      payload: utf8.encode(payload),
+    );
     _build(
       request,
       options,
@@ -213,7 +215,9 @@ class CoapClient {
       ),
       confirmable: confirmable,
       accept: accept,
-    )..setPayloadMediaRaw(payload, format);
+      contentFormat: format,
+      payload: payload,
+    );
     _build(
       request,
       options,
@@ -245,7 +249,9 @@ class CoapClient {
       ),
       confirmable: confirmable,
       accept: accept,
-    )..setPayloadMedia(payload, format);
+      contentFormat: format,
+      payload: utf8.encode(payload),
+    );
     _build(
       request,
       options,
@@ -279,7 +285,9 @@ class CoapClient {
       ),
       confirmable: confirmable,
       accept: accept,
-    )..setPayloadMediaRaw(payload, format);
+      contentFormat: format,
+      payload: payload,
+    );
     _build(
       request,
       options,
@@ -379,6 +387,7 @@ class CoapClient {
       confirmable: confirmable,
       payload: utf8.encode(payload),
       accept: accept,
+      contentFormat: format,
     );
     _build(
       request,
@@ -417,7 +426,9 @@ class CoapClient {
       ),
       confirmable: confirmable,
       accept: accept,
-    )..setPayloadMediaRaw(payload, format);
+      payload: payload,
+      contentFormat: format,
+    );
     _build(
       request,
       options,
@@ -455,7 +466,9 @@ class CoapClient {
       ),
       confirmable: confirmable,
       accept: accept,
-    )..setPayloadMedia(payload, format);
+      payload: utf8.encode(payload),
+      contentFormat: format,
+    );
     _build(
       request,
       options,
@@ -493,7 +506,9 @@ class CoapClient {
       ),
       confirmable: confirmable,
       accept: accept,
-    )..setPayloadMediaRaw(payload, format);
+      payload: payload,
+      contentFormat: format,
+    );
     _build(
       request,
       options,

--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -198,7 +198,7 @@ class CoapClient {
   /// Sends a POST request with the specified byte payload.
   Future<CoapResponse> postBytes(
     final String path, {
-    required final Uint8Buffer payload,
+    required final Iterable<int> payload,
     final String? query,
     final CoapMediaType? format,
     final CoapMediaType? accept,
@@ -266,7 +266,7 @@ class CoapClient {
   /// Sends a PUT request with the specified byte payload.
   Future<CoapResponse> putBytes(
     final String path, {
-    required final Uint8Buffer payload,
+    required final Iterable<int> payload,
     final String? query,
     final CoapMediaType? format,
     final MatchEtags matchEtags = MatchEtags.onMatch,
@@ -370,7 +370,7 @@ class CoapClient {
   /// [RFC 8132, section 2]: https://www.rfc-editor.org/rfc/rfc8132.html#section-2
   Future<CoapResponse> fetchBytes(
     final String path, {
-    required final Uint8Buffer payload,
+    required final Iterable<int> payload,
     final String? query,
     final CoapMediaType? accept,
     final CoapMediaType? format,
@@ -446,7 +446,7 @@ class CoapClient {
   /// [RFC 8132, section 3]: https://www.rfc-editor.org/rfc/rfc8132.html#section-3
   Future<CoapResponse> patchBytes(
     final String path, {
-    required final Uint8Buffer payload,
+    required final Iterable<int> payload,
     final String? query,
     final CoapMediaType? format,
     final MatchEtags matchEtags = MatchEtags.onMatch,
@@ -526,7 +526,7 @@ class CoapClient {
   /// [RFC 8132, section 3]: https://www.rfc-editor.org/rfc/rfc8132.html#section-3
   Future<CoapResponse> iPatchBytes(
     final String path, {
-    required final Uint8Buffer payload,
+    required final Iterable<int> payload,
     final String? query,
     final CoapMediaType? format,
     final MatchEtags matchEtags = MatchEtags.onMatch,

--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -334,6 +334,7 @@ class CoapClient {
   /// [RFC 8132, section 2]: https://www.rfc-editor.org/rfc/rfc8132.html#section-2
   Future<CoapResponse> fetch(
     final String path, {
+    required final String payload,
     final String? query,
     final CoapMediaType? accept,
     final CoapMediaType? format,
@@ -350,6 +351,8 @@ class CoapClient {
       ),
       confirmable: confirmable,
       accept: accept,
+      contentFormat: format,
+      payload: utf8.encode(payload),
     );
     _build(
       request,

--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -148,7 +148,6 @@ class CoapClient {
         CoapRequest.newGet(uri.replace(path: path), confirmable: confirmable);
     _build(
       request,
-      path,
       accept,
       options,
       earlyBlock2Negotiation,
@@ -174,7 +173,6 @@ class CoapClient {
           ..setPayloadMedia(payload, format);
     _build(
       request,
-      path,
       accept,
       options,
       earlyBlock2Negotiation,
@@ -200,7 +198,6 @@ class CoapClient {
           ..setPayloadMediaRaw(payload, format);
     _build(
       request,
-      path,
       accept,
       options,
       earlyBlock2Negotiation,
@@ -228,7 +225,6 @@ class CoapClient {
           ..setPayloadMedia(payload, format);
     _build(
       request,
-      path,
       accept,
       options,
       earlyBlock2Negotiation,
@@ -258,7 +254,6 @@ class CoapClient {
           ..setPayloadMediaRaw(payload, format);
     _build(
       request,
-      path,
       accept,
       options,
       earlyBlock2Negotiation,
@@ -285,7 +280,6 @@ class CoapClient {
     );
     _build(
       request,
-      path,
       accept,
       options,
       earlyBlock2Negotiation,
@@ -312,7 +306,6 @@ class CoapClient {
         CoapRequest.newFetch(uri.replace(path: path), confirmable: confirmable);
     _build(
       request,
-      path,
       accept,
       options,
       earlyBlock2Negotiation,
@@ -344,7 +337,6 @@ class CoapClient {
           ..setPayloadMedia(payload, format);
     _build(
       request,
-      path,
       accept,
       options,
       earlyBlock2Negotiation,
@@ -378,7 +370,6 @@ class CoapClient {
           ..setPayloadMediaRaw(payload, format);
     _build(
       request,
-      path,
       accept,
       options,
       earlyBlock2Negotiation,
@@ -412,7 +403,6 @@ class CoapClient {
           ..setPayloadMedia(payload, format);
     _build(
       request,
-      path,
       accept,
       options,
       earlyBlock2Negotiation,
@@ -446,7 +436,6 @@ class CoapClient {
           ..setPayloadMediaRaw(payload, format);
     _build(
       request,
-      path,
       accept,
       options,
       earlyBlock2Negotiation,
@@ -568,7 +557,6 @@ class CoapClient {
 
   void _build(
     final CoapRequest request,
-    final String path,
     final CoapMediaType? accept,
     final List<Option<Object?>>? options,
     final bool earlyBlock2Negotiation,

--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -521,11 +521,12 @@ class CoapClient {
 
   /// Discovers remote resources.
   Future<Iterable<CoapWebLink>?> discover({
-    final String query = '',
+    final String path = CoapConstants.defaultWellKnownURI,
+    final String? query,
   }) async {
     final discover = CoapRequest.newGet(
       uri.replace(
-        path: CoapConstants.defaultWellKnownURI,
+        path: path,
         query: query,
       ),
     );

--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -6,6 +6,7 @@
  */
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:collection/collection.dart';
@@ -151,10 +152,10 @@ class CoapClient {
         query: query,
       ),
       confirmable: confirmable,
+      accept: accept,
     );
     _build(
       request,
-      accept,
       options,
       earlyBlock2Negotiation,
       maxRetransmit,
@@ -181,10 +182,10 @@ class CoapClient {
         query: query,
       ),
       confirmable: confirmable,
+      accept: accept,
     )..setPayloadMedia(payload, format);
     _build(
       request,
-      accept,
       options,
       earlyBlock2Negotiation,
       maxRetransmit,
@@ -211,10 +212,10 @@ class CoapClient {
         query: query,
       ),
       confirmable: confirmable,
+      accept: accept,
     )..setPayloadMediaRaw(payload, format);
     _build(
       request,
-      accept,
       options,
       earlyBlock2Negotiation,
       maxRetransmit,
@@ -243,10 +244,10 @@ class CoapClient {
         query: query,
       ),
       confirmable: confirmable,
+      accept: accept,
     )..setPayloadMedia(payload, format);
     _build(
       request,
-      accept,
       options,
       earlyBlock2Negotiation,
       maxRetransmit,
@@ -277,10 +278,10 @@ class CoapClient {
         query: query,
       ),
       confirmable: confirmable,
+      accept: accept,
     )..setPayloadMediaRaw(payload, format);
     _build(
       request,
-      accept,
       options,
       earlyBlock2Negotiation,
       maxRetransmit,
@@ -307,10 +308,10 @@ class CoapClient {
         query: query,
       ),
       confirmable: confirmable,
+      accept: accept,
     );
     _build(
       request,
-      accept,
       options,
       earlyBlock2Negotiation,
       maxRetransmit,
@@ -327,6 +328,7 @@ class CoapClient {
     final String path, {
     final String? query,
     final CoapMediaType? accept,
+    final CoapMediaType? format,
     final bool confirmable = true,
     final List<Option<Object?>>? options,
     final bool earlyBlock2Negotiation = false,
@@ -339,10 +341,10 @@ class CoapClient {
         query: query,
       ),
       confirmable: confirmable,
+      accept: accept,
     );
     _build(
       request,
-      accept,
       options,
       earlyBlock2Negotiation,
       maxRetransmit,
@@ -375,10 +377,11 @@ class CoapClient {
         query: query,
       ),
       confirmable: confirmable,
-    )..setPayloadMedia(payload, format);
+      payload: utf8.encode(payload),
+      accept: accept,
+    );
     _build(
       request,
-      accept,
       options,
       earlyBlock2Negotiation,
       maxRetransmit,
@@ -413,10 +416,10 @@ class CoapClient {
         query: query,
       ),
       confirmable: confirmable,
+      accept: accept,
     )..setPayloadMediaRaw(payload, format);
     _build(
       request,
-      accept,
       options,
       earlyBlock2Negotiation,
       maxRetransmit,
@@ -451,10 +454,10 @@ class CoapClient {
         query: query,
       ),
       confirmable: confirmable,
+      accept: accept,
     )..setPayloadMedia(payload, format);
     _build(
       request,
-      accept,
       options,
       earlyBlock2Negotiation,
       maxRetransmit,
@@ -489,10 +492,10 @@ class CoapClient {
         query: query,
       ),
       confirmable: confirmable,
+      accept: accept,
     )..setPayloadMediaRaw(payload, format);
     _build(
       request,
-      accept,
       options,
       earlyBlock2Negotiation,
       maxRetransmit,
@@ -614,16 +617,13 @@ class CoapClient {
 
   void _build(
     final CoapRequest request,
-    final CoapMediaType? accept,
     final List<Option<Object?>>? options,
     final bool earlyBlock2Negotiation,
     final int maxRetransmit, {
     final MatchEtags matchEtags = MatchEtags.onMatch,
     final List<Uint8Buffer>? etags,
   }) {
-    request
-      ..accept = accept
-      ..maxRetransmit = maxRetransmit;
+    request.maxRetransmit = maxRetransmit;
     if (options != null) {
       request.addOptions(options);
     }

--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -137,6 +137,7 @@ class CoapClient {
   /// Sends a GET request.
   Future<CoapResponse> get(
     final String path, {
+    final String? query,
     final CoapMediaType? accept,
     final bool confirmable = true,
     final List<Option<Object?>>? options,
@@ -144,8 +145,13 @@ class CoapClient {
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request =
-        CoapRequest.newGet(uri.replace(path: path), confirmable: confirmable);
+    final request = CoapRequest.newGet(
+      uri.replace(
+        path: path,
+        query: query,
+      ),
+      confirmable: confirmable,
+    );
     _build(
       request,
       accept,
@@ -160,6 +166,7 @@ class CoapClient {
   Future<CoapResponse> post(
     final String path, {
     required final String payload,
+    final String? query,
     final CoapMediaType? format,
     final CoapMediaType? accept,
     final bool confirmable = true,
@@ -168,9 +175,13 @@ class CoapClient {
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request =
-        CoapRequest.newPost(uri.replace(path: path), confirmable: confirmable)
-          ..setPayloadMedia(payload, format);
+    final request = CoapRequest.newPost(
+      uri.replace(
+        path: path,
+        query: query,
+      ),
+      confirmable: confirmable,
+    )..setPayloadMedia(payload, format);
     _build(
       request,
       accept,
@@ -185,6 +196,7 @@ class CoapClient {
   Future<CoapResponse> postBytes(
     final String path, {
     required final Uint8Buffer payload,
+    final String? query,
     final CoapMediaType? format,
     final CoapMediaType? accept,
     final bool confirmable = true,
@@ -193,9 +205,13 @@ class CoapClient {
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request =
-        CoapRequest.newPost(uri.replace(path: path), confirmable: confirmable)
-          ..setPayloadMediaRaw(payload, format);
+    final request = CoapRequest.newPost(
+      uri.replace(
+        path: path,
+        query: query,
+      ),
+      confirmable: confirmable,
+    )..setPayloadMediaRaw(payload, format);
     _build(
       request,
       accept,
@@ -210,6 +226,7 @@ class CoapClient {
   Future<CoapResponse> put(
     final String path, {
     required final String payload,
+    final String? query,
     final CoapMediaType? format,
     final CoapMediaType? accept,
     final bool confirmable = true,
@@ -220,9 +237,13 @@ class CoapClient {
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request =
-        CoapRequest.newPut(uri.replace(path: path), confirmable: confirmable)
-          ..setPayloadMedia(payload, format);
+    final request = CoapRequest.newPut(
+      uri.replace(
+        path: path,
+        query: query,
+      ),
+      confirmable: confirmable,
+    )..setPayloadMedia(payload, format);
     _build(
       request,
       accept,
@@ -239,6 +260,7 @@ class CoapClient {
   Future<CoapResponse> putBytes(
     final String path, {
     required final Uint8Buffer payload,
+    final String? query,
     final CoapMediaType? format,
     final MatchEtags matchEtags = MatchEtags.onMatch,
     final List<Uint8Buffer>? etags,
@@ -249,9 +271,13 @@ class CoapClient {
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request =
-        CoapRequest.newPut(uri.replace(path: path), confirmable: confirmable)
-          ..setPayloadMediaRaw(payload, format);
+    final request = CoapRequest.newPut(
+      uri.replace(
+        path: path,
+        query: query,
+      ),
+      confirmable: confirmable,
+    )..setPayloadMediaRaw(payload, format);
     _build(
       request,
       accept,
@@ -267,6 +293,7 @@ class CoapClient {
   /// Sends a DELETE request
   Future<CoapResponse> delete(
     final String path, {
+    final String? query,
     final CoapMediaType? accept,
     final bool confirmable = true,
     final List<Option<Object?>>? options,
@@ -275,7 +302,10 @@ class CoapClient {
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
     final request = CoapRequest.newDelete(
-      uri.replace(path: path),
+      uri.replace(
+        path: path,
+        query: query,
+      ),
       confirmable: confirmable,
     );
     _build(
@@ -295,6 +325,7 @@ class CoapClient {
   /// [RFC 8132, section 2]: https://www.rfc-editor.org/rfc/rfc8132.html#section-2
   Future<CoapResponse> fetch(
     final String path, {
+    final String? query,
     final CoapMediaType? accept,
     final bool confirmable = true,
     final List<Option<Object?>>? options,
@@ -302,8 +333,13 @@ class CoapClient {
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request =
-        CoapRequest.newFetch(uri.replace(path: path), confirmable: confirmable);
+    final request = CoapRequest.newFetch(
+      uri.replace(
+        path: path,
+        query: query,
+      ),
+      confirmable: confirmable,
+    );
     _build(
       request,
       accept,
@@ -322,6 +358,7 @@ class CoapClient {
   Future<CoapResponse> patch(
     final String path, {
     required final String payload,
+    final String? query,
     final CoapMediaType? format,
     final CoapMediaType? accept,
     final bool confirmable = true,
@@ -332,9 +369,13 @@ class CoapClient {
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request =
-        CoapRequest.newPatch(uri.replace(path: path), confirmable: confirmable)
-          ..setPayloadMedia(payload, format);
+    final request = CoapRequest.newPatch(
+      uri.replace(
+        path: path,
+        query: query,
+      ),
+      confirmable: confirmable,
+    )..setPayloadMedia(payload, format);
     _build(
       request,
       accept,
@@ -355,6 +396,7 @@ class CoapClient {
   Future<CoapResponse> patchBytes(
     final String path, {
     required final Uint8Buffer payload,
+    final String? query,
     final CoapMediaType? format,
     final MatchEtags matchEtags = MatchEtags.onMatch,
     final List<Uint8Buffer>? etags,
@@ -365,9 +407,13 @@ class CoapClient {
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request =
-        CoapRequest.newPatch(uri.replace(path: path), confirmable: confirmable)
-          ..setPayloadMediaRaw(payload, format);
+    final request = CoapRequest.newPatch(
+      uri.replace(
+        path: path,
+        query: query,
+      ),
+      confirmable: confirmable,
+    )..setPayloadMediaRaw(payload, format);
     _build(
       request,
       accept,
@@ -388,6 +434,7 @@ class CoapClient {
   Future<CoapResponse> iPatch(
     final String path, {
     required final String payload,
+    final String? query,
     final CoapMediaType? format,
     final CoapMediaType? accept,
     final bool confirmable = true,
@@ -398,9 +445,13 @@ class CoapClient {
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request =
-        CoapRequest.newIPatch(uri.replace(path: path), confirmable: confirmable)
-          ..setPayloadMedia(payload, format);
+    final request = CoapRequest.newIPatch(
+      uri.replace(
+        path: path,
+        query: query,
+      ),
+      confirmable: confirmable,
+    )..setPayloadMedia(payload, format);
     _build(
       request,
       accept,
@@ -421,6 +472,7 @@ class CoapClient {
   Future<CoapResponse> iPatchBytes(
     final String path, {
     required final Uint8Buffer payload,
+    final String? query,
     final CoapMediaType? format,
     final MatchEtags matchEtags = MatchEtags.onMatch,
     final List<Uint8Buffer>? etags,
@@ -431,9 +483,13 @@ class CoapClient {
     final int maxRetransmit = 0,
     final CoapMulticastResponseHandler? onMulticastResponse,
   }) {
-    final request =
-        CoapRequest.newIPatch(uri.replace(path: path), confirmable: confirmable)
-          ..setPayloadMediaRaw(payload, format);
+    final request = CoapRequest.newIPatch(
+      uri.replace(
+        path: path,
+        query: query,
+      ),
+      confirmable: confirmable,
+    )..setPayloadMediaRaw(payload, format);
     _build(
       request,
       accept,

--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -363,6 +363,42 @@ class CoapClient {
     return send(request, onMulticastResponse: onMulticastResponse);
   }
 
+  /// Sends a FETCH request with the specified byte payload.
+  ///
+  /// See [RFC 8132, section 2].
+  ///
+  /// [RFC 8132, section 2]: https://www.rfc-editor.org/rfc/rfc8132.html#section-2
+  Future<CoapResponse> fetchBytes(
+    final String path, {
+    required final Uint8Buffer payload,
+    final String? query,
+    final CoapMediaType? accept,
+    final CoapMediaType? format,
+    final bool confirmable = true,
+    final List<Option<Object?>>? options,
+    final bool earlyBlock2Negotiation = false,
+    final int maxRetransmit = 0,
+    final CoapMulticastResponseHandler? onMulticastResponse,
+  }) {
+    final request = CoapRequest.newFetch(
+      uri.replace(
+        path: path,
+        query: query,
+      ),
+      confirmable: confirmable,
+      accept: accept,
+      contentFormat: format,
+      payload: payload,
+    );
+    _build(
+      request,
+      options,
+      earlyBlock2Negotiation,
+      maxRetransmit,
+    );
+    return send(request, onMulticastResponse: onMulticastResponse);
+  }
+
   /// Sends a PATCH request.
   ///
   /// See [RFC 8132, section 3].

--- a/lib/src/coap_message.dart
+++ b/lib/src/coap_message.dart
@@ -41,8 +41,7 @@ abstract class CoapMessage {
     this._type, {
     final Iterable<int>? payload,
     final CoapMediaType? contentFormat,
-  }) {
-    this.payload = Uint8Buffer()..addAll(payload ?? []);
+  }) : payload = Uint8Buffer()..addAll(payload ?? []) {
     contentType = contentFormat;
   }
 
@@ -55,10 +54,9 @@ abstract class CoapMessage {
     required final Uint8Buffer? payload,
     required this.hasUnknownCriticalOption,
     required this.hasFormatError,
-  }) {
+  }) : payload = payload ?? Uint8Buffer() {
     this.id = id;
     this.token = token;
-    this.payload = payload ?? [];
     setOptions(options);
   }
 
@@ -304,14 +302,8 @@ abstract class CoapMessage {
   /// The default value is 0.
   int ackTimeout = 0;
 
-  final Uint8Buffer _payload = Uint8Buffer();
-
   /// The payload of this CoAP message.
-  Uint8Buffer get payload => _payload;
-
-  set payload(final Iterable<int> payload) => _payload
-    ..clear()
-    ..addAll(payload);
+  final Uint8Buffer payload;
 
   /// The size of the payload of this CoAP message.
   int get payloadSize => payload.length;
@@ -330,28 +322,6 @@ abstract class CoapMessage {
       }
     }
     return '';
-  }
-
-  /// Sets the payload from a string with a default media type
-  set payloadString(final String value) =>
-      setPayloadMedia(value, CoapMediaType.textPlain);
-
-  /// Sets the payload.
-  void setPayload(final String payload) => this.payload = utf8.encode(payload);
-
-  /// Sets the payload and media type of this CoAP message.
-  void setPayloadMedia(final String payload, [final CoapMediaType? mediaType]) {
-    setPayload(payload);
-    contentType = mediaType;
-  }
-
-  /// Sets the payload of this CoAP message.
-  void setPayloadMediaRaw(
-    final Uint8Buffer payload, [
-    final CoapMediaType? mediaType,
-  ]) {
-    this.payload = payload;
-    contentType = mediaType;
   }
 
   /// If-Matches.

--- a/lib/src/coap_message.dart
+++ b/lib/src/coap_message.dart
@@ -40,8 +40,10 @@ abstract class CoapMessage {
     this.code,
     this._type, {
     final Iterable<int>? payload,
+    final CoapMediaType? contentFormat,
   }) {
     this.payload = Uint8Buffer()..addAll(payload ?? []);
+    contentType = contentFormat;
   }
 
   CoapMessage.fromParsed(

--- a/lib/src/coap_message.dart
+++ b/lib/src/coap_message.dart
@@ -36,7 +36,13 @@ typedef HookFunction = void Function();
 /// each of which has a MessageType, a message identifier,
 /// a token (0-8 bytes), a collection of Options and a payload.
 abstract class CoapMessage {
-  CoapMessage(this.code, this._type);
+  CoapMessage(
+    this.code,
+    this._type, {
+    final Iterable<int>? payload,
+  }) {
+    this.payload = Uint8Buffer()..addAll(payload ?? []);
+  }
 
   CoapMessage.fromParsed(
     this.code,

--- a/lib/src/coap_request.dart
+++ b/lib/src/coap_request.dart
@@ -23,8 +23,12 @@ import 'option/uri_converters.dart';
 class CoapRequest extends CoapMessage {
   /// Initializes a request message.
   /// Defaults to confirmable
-  CoapRequest(this.uri, this.method, {final bool confirmable = true})
-      : super(
+  CoapRequest(
+    this.uri,
+    this.method, {
+    final bool confirmable = true,
+    super.payload,
+  }) : super(
           method.coapCode,
           confirmable ? CoapMessageType.con : CoapMessageType.non,
         );
@@ -73,44 +77,95 @@ class CoapRequest extends CoapMessage {
   String toString() => '\n<<< Request Message >>>${super.toString()}';
 
   /// Construct a GET request.
-  factory CoapRequest.newGet(final Uri uri, {final bool confirmable = true}) =>
-      CoapRequest(uri, RequestMethod.get, confirmable: confirmable);
+  factory CoapRequest.newGet(
+    final Uri uri, {
+    final bool confirmable = true,
+    final Iterable<int>? payload,
+  }) =>
+      CoapRequest(
+        uri,
+        RequestMethod.get,
+        confirmable: confirmable,
+        payload: payload,
+      );
 
   /// Construct a POST request.
-  factory CoapRequest.newPost(final Uri uri, {final bool confirmable = true}) =>
-      CoapRequest(uri, RequestMethod.post, confirmable: confirmable);
+  factory CoapRequest.newPost(
+    final Uri uri, {
+    final bool confirmable = true,
+    final Iterable<int>? payload,
+  }) =>
+      CoapRequest(
+        uri,
+        RequestMethod.post,
+        confirmable: confirmable,
+        payload: payload,
+      );
 
   /// Construct a PUT request.
-  factory CoapRequest.newPut(final Uri uri, {final bool confirmable = true}) =>
-      CoapRequest(uri, RequestMethod.put, confirmable: confirmable);
+  factory CoapRequest.newPut(
+    final Uri uri, {
+    final bool confirmable = true,
+    final Iterable<int>? payload,
+  }) =>
+      CoapRequest(
+        uri,
+        RequestMethod.put,
+        confirmable: confirmable,
+        payload: payload,
+      );
 
   /// Construct a DELETE request.
   factory CoapRequest.newDelete(
     final Uri uri, {
     final bool confirmable = true,
+    final Iterable<int>? payload,
   }) =>
-      CoapRequest(uri, RequestMethod.delete, confirmable: confirmable);
+      CoapRequest(
+        uri,
+        RequestMethod.delete,
+        confirmable: confirmable,
+        payload: payload,
+      );
 
   /// Construct a FETCH request.
   factory CoapRequest.newFetch(
     final Uri uri, {
     final bool confirmable = true,
+    final Iterable<int>? payload,
   }) =>
-      CoapRequest(uri, RequestMethod.fetch, confirmable: confirmable);
+      CoapRequest(
+        uri,
+        RequestMethod.fetch,
+        confirmable: confirmable,
+        payload: payload,
+      );
 
   /// Construct a PATCH request.
   factory CoapRequest.newPatch(
     final Uri uri, {
     final bool confirmable = true,
+    final Iterable<int>? payload,
   }) =>
-      CoapRequest(uri, RequestMethod.patch, confirmable: confirmable);
+      CoapRequest(
+        uri,
+        RequestMethod.patch,
+        confirmable: confirmable,
+        payload: payload,
+      );
 
   /// Construct a iPATCH request.
   factory CoapRequest.newIPatch(
     final Uri uri, {
     final bool confirmable = true,
+    final Iterable<int>? payload,
   }) =>
-      CoapRequest(uri, RequestMethod.ipatch, confirmable: confirmable);
+      CoapRequest(
+        uri,
+        RequestMethod.ipatch,
+        confirmable: confirmable,
+        payload: payload,
+      );
 
   CoapRequest.fromParsed(
     this.uri,

--- a/lib/src/coap_request.dart
+++ b/lib/src/coap_request.dart
@@ -9,6 +9,7 @@ import 'package:meta/meta.dart';
 import 'package:typed_data/typed_buffers.dart';
 
 import 'coap_code.dart';
+import 'coap_media_type.dart';
 import 'coap_message.dart';
 import 'coap_message_type.dart';
 import 'net/endpoint.dart';
@@ -28,10 +29,14 @@ class CoapRequest extends CoapMessage {
     this.method, {
     final bool confirmable = true,
     super.payload,
+    final CoapMediaType? accept,
+    super.contentFormat,
   }) : super(
           method.coapCode,
           confirmable ? CoapMessageType.con : CoapMessageType.non,
-        );
+        ) {
+    super.accept = accept;
+  }
 
   /// The request method(code)
   final RequestMethod method;
@@ -81,12 +86,14 @@ class CoapRequest extends CoapMessage {
     final Uri uri, {
     final bool confirmable = true,
     final Iterable<int>? payload,
+    final CoapMediaType? accept,
   }) =>
       CoapRequest(
         uri,
         RequestMethod.get,
         confirmable: confirmable,
         payload: payload,
+        accept: accept,
       );
 
   /// Construct a POST request.
@@ -94,12 +101,16 @@ class CoapRequest extends CoapMessage {
     final Uri uri, {
     final bool confirmable = true,
     final Iterable<int>? payload,
+    final CoapMediaType? contentFormat,
+    final CoapMediaType? accept,
   }) =>
       CoapRequest(
         uri,
         RequestMethod.post,
         confirmable: confirmable,
         payload: payload,
+        contentFormat: contentFormat,
+        accept: accept,
       );
 
   /// Construct a PUT request.
@@ -107,12 +118,16 @@ class CoapRequest extends CoapMessage {
     final Uri uri, {
     final bool confirmable = true,
     final Iterable<int>? payload,
+    final CoapMediaType? contentFormat,
+    final CoapMediaType? accept,
   }) =>
       CoapRequest(
         uri,
         RequestMethod.put,
         confirmable: confirmable,
         payload: payload,
+        contentFormat: contentFormat,
+        accept: accept,
       );
 
   /// Construct a DELETE request.
@@ -120,12 +135,14 @@ class CoapRequest extends CoapMessage {
     final Uri uri, {
     final bool confirmable = true,
     final Iterable<int>? payload,
+    final CoapMediaType? accept,
   }) =>
       CoapRequest(
         uri,
         RequestMethod.delete,
         confirmable: confirmable,
         payload: payload,
+        accept: accept,
       );
 
   /// Construct a FETCH request.
@@ -133,12 +150,16 @@ class CoapRequest extends CoapMessage {
     final Uri uri, {
     final bool confirmable = true,
     final Iterable<int>? payload,
+    final CoapMediaType? contentFormat,
+    final CoapMediaType? accept,
   }) =>
       CoapRequest(
         uri,
         RequestMethod.fetch,
         confirmable: confirmable,
         payload: payload,
+        contentFormat: contentFormat,
+        accept: accept,
       );
 
   /// Construct a PATCH request.
@@ -146,12 +167,16 @@ class CoapRequest extends CoapMessage {
     final Uri uri, {
     final bool confirmable = true,
     final Iterable<int>? payload,
+    final CoapMediaType? contentFormat,
+    final CoapMediaType? accept,
   }) =>
       CoapRequest(
         uri,
         RequestMethod.patch,
         confirmable: confirmable,
         payload: payload,
+        contentFormat: contentFormat,
+        accept: accept,
       );
 
   /// Construct a iPATCH request.
@@ -159,12 +184,16 @@ class CoapRequest extends CoapMessage {
     final Uri uri, {
     final bool confirmable = true,
     final Iterable<int>? payload,
+    final CoapMediaType? contentFormat,
+    final CoapMediaType? accept,
   }) =>
       CoapRequest(
         uri,
         RequestMethod.ipatch,
         confirmable: confirmable,
         payload: payload,
+        contentFormat: contentFormat,
+        accept: accept,
       );
 
   CoapRequest.fromParsed(

--- a/lib/src/coap_response.dart
+++ b/lib/src/coap_response.dart
@@ -24,6 +24,7 @@ class CoapResponse extends CoapMessage {
     this.responseCode,
     final CoapMessageType type, {
     final Uri? location,
+    super.payload,
   })  : location = location ?? Uri(path: '/'),
         super(responseCode.coapCode, type);
 
@@ -86,8 +87,14 @@ class CoapResponse extends CoapMessage {
     final ResponseCode statusCode,
     final CoapMessageType type, {
     final Uri? location,
+    final Iterable<int>? payload,
   }) =>
-      CoapResponse(statusCode, type, location: location)
+      CoapResponse(
+        statusCode,
+        type,
+        location: location,
+        payload: payload,
+      )
         ..destination = request.source
         ..token = request.token;
 

--- a/test/coap_message_api_test.dart
+++ b/test/coap_message_api_test.dart
@@ -165,9 +165,11 @@ void main() {
   });
 
   test('Payload', () {
-    final message = CoapEmptyMessage(CoapMessageType.rst)
-      ..isTimedOut = true
-      ..setPayload('This is the payload');
+    final message = CoapRequest(
+      Uri.parse("coap://coap.me"),
+      RequestMethod.get,
+      payload: utf8.encode('This is the payload'),
+    )..isTimedOut = true;
     expect(message.payload, isNotNull);
     expect(message.payloadString, 'This is the payload');
     expect(message.payloadSize, 19);

--- a/test/coap_message_encode_decode_test.dart
+++ b/test/coap_message_encode_decode_test.dart
@@ -6,6 +6,8 @@
  * Date   : 13/04/2017
  * Copyright :  S.Hamblett
  */
+import 'dart:convert';
+
 import 'package:coap/coap.dart';
 import 'package:coap/src/coap_message.dart';
 import 'package:coap/src/codec/udp/message_decoder.dart';
@@ -225,10 +227,11 @@ void main() {
     }
 
     void testMessage(final int testNo) {
-      final msg =
-          CoapRequest(Uri.parse('coap://example.org'), RequestMethod.get)
-            ..id = 12345
-            ..setPayload('payload');
+      final msg = CoapRequest(
+        Uri.parse('coap://example.org'),
+        RequestMethod.get,
+        payload: utf8.encode('payload'),
+      )..id = 12345;
       final data = serializeUdpMessage(msg);
       checkData(data, testNo);
       final convMsg = deserializeUdpMessage(data, 'coap');
@@ -244,14 +247,16 @@ void main() {
     }
 
     void testMessageWithOptions(final int testNo) {
-      final CoapMessage msg =
-          CoapRequest(Uri.parse('coap://example.org'), RequestMethod.get)
-            ..id = 12345
-            ..setPayload('payload')
-            ..addOption(
-              ContentFormatOption(CoapMediaType.textPlain.numericValue),
-            )
-            ..addOption(MaxAgeOption(30));
+      final CoapMessage msg = CoapRequest(
+        Uri.parse('coap://example.org'),
+        RequestMethod.get,
+        payload: utf8.encode('payload'),
+      )
+        ..id = 12345
+        ..addOption(
+          ContentFormatOption(CoapMediaType.textPlain.numericValue),
+        )
+        ..addOption(MaxAgeOption(30));
       expect(msg.getFirstOption<ContentFormatOption>()!.value, 0);
       expect(msg.getFirstOption<MaxAgeOption>()!.value, 30);
       final data = serializeUdpMessage(msg);
@@ -281,12 +286,14 @@ void main() {
     }
 
     void testMessageWithExtendedOption(final int testNo) {
-      final CoapMessage msg =
-          CoapRequest(Uri.parse('coap://example.org'), RequestMethod.get)
-            ..id = 12345
-            ..addOption(ContentFormatOption(0));
+      final CoapMessage msg = CoapRequest(
+        Uri.parse('coap://example.org'),
+        RequestMethod.get,
+        payload: utf8.encode('payload'),
+      )
+        ..id = 12345
+        ..addOption(ContentFormatOption(0));
       expect(msg.getFirstOption<ContentFormatOption>()!.value, 0);
-      msg.setPayload('payload');
 
       final data = serializeUdpMessage(msg);
       checkData(data, testNo);


### PR DESCRIPTION
This PR makes a couple of improvements to the request API by adding a `query` parameter, adding payload-related parameters to the `fetch` method (which actually is the main USP of this request method), and changing the type of the payload parameter from `Uint8Buffer` to `Iterable<int>`, increasing the number of possible input types (by including types like `Uint8List` or `List<int>`).

The PR also applies some additional clean up, getting rid of some getters and setters that are not actually needed.