### PR TITLE
chore(deps): update dtls2 to version 0.13.4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   build: ^2.3.0
   collection: ^1.16.0
   convert: ^3.0.2
-  dtls2: ^0.12.0
+  dtls2: ^0.13.4
   event_bus: ^2.0.0
   meta: ^1.9.0
   path: ^1.8.2


### PR DESCRIPTION
This PR updates the `dtls2` dependency to the latest version.