### PR TITLE
chore: upgrade `dtls2` to version 0.16.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   build: ^2.4.0
   collection: ^1.17.2
   convert: ^3.1.1
-  dtls2: ^0.15.0
+  dtls2: ^0.16.0
   event_bus: ^2.0.0
   meta: ^1.9.0
   path: ^1.8.3


### PR DESCRIPTION
I just released a new version of the `dtls2` package with some additional bug fixes. This PR bumps the version number.