### PR TITLE
Update dtls2 package to version 0.17.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   build: ^2.4.1
   collection: ^1.18.0
   convert: ^3.1.1
-  dtls2: ^0.16.0
+  dtls2: ^0.17.0
   event_bus: ^2.0.0
   meta: ^1.12.0
   path: ^1.9.0


### PR DESCRIPTION
This PR updates the dtls2 package to the latest version.

There are currently a couple of issues when trying to use the CoAPS example with newer versions of DTLS because they have deprecated a number of cipher suites, including the mandatory one for CoAP (`TLS_PSK_WITH_AES_128_CCM_8`), making it necessary to explicitly state that you want to them, which is a bit annoying. I will create another patch version soon that will address this issue and make the package usable in this context again.