### PR TITLE
ci: add workaround for failing CI on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,24 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        # TODO: Revert once https://github.com/dart-lang/sdk/issues/55745
+        #       has been resolved
+
+        sdk: [stable, 3.3.0]
+        exclude:
+          - os: macos-latest
+            sdk: 3.3.0
+          - os: ubuntu-latest
+            sdk: 3.3.0
+          - os: windows-latest
+            sdk: stable
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: ${{ matrix.sdk }}
 
       - name: Install dependencies
         run: dart pub get


### PR DESCRIPTION
As mentioned in #189, there is currently an issue with the CI when it is running under Dart 3.4.0 and Windows. This issue adds a workaround that lets the CI fall back to 3.3.0 under Windows so that the respective job does not fail anymore due to a timeout. As soon as the issue has been fixed upstream, this change can be reverted.