### PR TITLE
Fix: first observe response not being handled

### DIFF
--- a/lib/src/coap_client.dart
+++ b/lib/src/coap_client.dart
@@ -511,8 +511,8 @@ class CoapClient {
   /// Observe
   Future<CoapObserveClientRelation> observe(
     final CoapRequest request, {
-    final int maxRetransmit = 0,
-  }) async {
+      final int maxRetransmit = 0,
+    }) async {
     var isObserving = false;
     request
       ..observe = ObserveRegistration.register.value
@@ -525,10 +525,7 @@ class CoapClient {
       },
     );
     final relation = CoapObserveClientRelation(request, responseStream);
-    final resp = await _waitForResponse(request, responseStream);
-    if (!resp.hasOption<ObserveOption>()) {
-      relation.isCancelled = true;
-    }
+    relation.checkObserve();
     isObserving = true;
     return relation;
   }

--- a/lib/src/coap_observe_client_relation.dart
+++ b/lib/src/coap_observe_client_relation.dart
@@ -55,13 +55,12 @@ class CoapObserveClientRelation extends Stream<CoapResponse> {
     return requestToken.equals(responseToken);
   }
 
-  bool checkObserve() {
+  void checkObserve() {
     _filteredStream.first.then((resp) {
       if (!resp.hasOption<ObserveOption>()) {
         isCancelled = true;
       }
     });
-    return true;
   }
 
   bool _cancelled = false;

--- a/lib/src/coap_observe_client_relation.dart
+++ b/lib/src/coap_observe_client_relation.dart
@@ -57,7 +57,6 @@ class CoapObserveClientRelation extends Stream<CoapResponse> {
 
   bool checkObserve() {
     _filteredStream.first.then((resp) {
-      print(resp.hasOption<ObserveOption>());
       if (!resp.hasOption<ObserveOption>()) {
         isCancelled = true;
       }

--- a/lib/src/coap_observe_client_relation.dart
+++ b/lib/src/coap_observe_client_relation.dart
@@ -55,6 +55,16 @@ class CoapObserveClientRelation extends Stream<CoapResponse> {
     return requestToken.equals(responseToken);
   }
 
+  bool checkObserve() {
+    _filteredStream.first.then((resp) {
+      print(resp.hasOption<ObserveOption>());
+      if (!resp.hasOption<ObserveOption>()) {
+        isCancelled = true;
+      }
+    });
+    return true;
+  }
+
   bool _cancelled = false;
 
   /// Cancelled


### PR DESCRIPTION
PR related to issue #193

To prevent the check from blocking the function until after the first response is received, I created a method within the `CoapObserveClientRelation` called `checkObserve` that checks for the observe flag upon receiving the first response. This approach eliminates the need for await, ensuring that the `CoapObserveClientRelation` object already has our `onData` method when the first response is received.