### PR TITLE
chore!: update dtls2 package to version 0.18.0

### DIFF
--- a/lib/coap.dart
+++ b/lib/coap.dart
@@ -7,6 +7,9 @@
 
 library coap;
 
+export 'package:dtls2/dtls2.dart'
+    show Certificate, PemCertificate, DerCertificate;
+
 /// Pre-defined configs
 export 'config/coap_config_all.dart';
 export 'config/coap_config_default.dart';

--- a/lib/src/coap_config.dart
+++ b/lib/src/coap_config.dart
@@ -7,6 +7,7 @@
 
 import 'dart:typed_data';
 import 'dart:ffi';
+import 'package:dtls2/dtls2.dart';
 
 import 'coap_constants.dart';
 import 'deduplication/deduplicator_factory.dart';
@@ -79,7 +80,7 @@ abstract class DefaultCoapConfig {
   bool get dtlsWithTrustedRoots => true;
 
   /// List of custom root certificates to use with OpenSSL.
-  List<Uint8List> get rootCertificates => const [];
+  List<Certificate> get rootCertificates => const [];
 
   /// Can be used to specify the Ciphers that should be used by OpenSSL.
   String? get dtlsCiphers => null;

--- a/lib/src/network/coap_network_openssl.dart
+++ b/lib/src/network/coap_network_openssl.dart
@@ -58,7 +58,7 @@ class CoapNetworkUDPOpenSSL extends CoapNetworkUDP {
     super.bindAddress, {
     required final bool verify,
     required final bool withTrustedRoots,
-    required final List<Uint8List> rootCertificates,
+    required final List<Certificate> rootCertificates,
     super.namespace,
     final String? ciphers,
     final internal.PskCredentialsCallback? pskCredentialsCallback,
@@ -78,7 +78,7 @@ class CoapNetworkUDPOpenSSL extends CoapNetworkUDP {
 
   DtlsConnection? _dtlsConnection;
 
-  final List<Uint8List> _rootCertificates;
+  final List<Certificate> _rootCertificates;
 
   final bool _verify;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   build: ^2.4.1
   collection: ^1.18.0
   convert: ^3.1.1
-  dtls2: ^0.17.0
+  dtls2: ^0.18.0
   event_bus: ^2.0.0
   meta: ^1.12.0
   path: ^1.9.0


### PR DESCRIPTION
This PR updates the `dtls2` package to the latest version. Since there have been API changes in `dtls2` regarding the handling of certificates, the relevant parts of the API for this package are modified accordingly and the certificate classes in question are re-exported.

The main benefit of this change is now that you are able to provide root certificates that can also be in PEM format, making the use of DTLS in PKI mode a bit more versatile and the API itself clearer. However, as there are API changes involved, they have to be considered breaking changes.