### PR TITLE
ci: remove unused matrix.sdk variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1
-        with:
-          sdk: ${{ matrix.sdk }}
 
       - name: Install dependencies
         run: dart pub get


### PR DESCRIPTION
I noticed a minor leftover of the workaround introduced by https://github.com/shamblett/coap/pull/191, which can now be safely removed.