### PR TITLE
chore: remove unused import

### DIFF
--- a/lib/src/coap_config.dart
+++ b/lib/src/coap_config.dart
@@ -5,7 +5,6 @@
  * Copyright :  S.Hamblett
  */
 
-import 'dart:typed_data';
 import 'dart:ffi';
 import 'package:dtls2/dtls2.dart';
 


### PR DESCRIPTION
This is another trivial PR removing a leftover import that has become unnecessary after the merge of #200. Merging this one will grant the package the full score in the "Pass static analysis" category again.