### PR TITLE
Allow for overriding the OpenSSL security level

### DIFF
--- a/example/get_resource_secure.dart
+++ b/example/get_resource_secure.dart
@@ -30,6 +30,14 @@ PskCredentials pskCredentialsCallback(final String? identityHint) =>
 class DtlsConfig extends DefaultCoapConfig {
   @override
   String? get dtlsCiphers => 'PSK-AES128-CCM8';
+
+  @override
+  // Since TLS_PSK_WITH_AES_128_CCM_8 (also known as PSK-AES128-CCM8 in OpenSSL)
+  // is considered insecure in more recent versions of OpenSSL, we reduce the
+  // security level here, as TLS_PSK_WITH_AES_128_CCM_8 is the mandatory cipher
+  // suite that CoAP implementations must support when using DTLS in PSK mode
+  // (see section 9.1.3.1 of RFC 7252).
+  int? get openSslSecurityLevel => 0;
 }
 
 FutureOr<void> main() async {

--- a/lib/src/coap_config.dart
+++ b/lib/src/coap_config.dart
@@ -91,4 +91,13 @@ abstract class DefaultCoapConfig {
   /// Custom libcrypto instance that can be registered if OpenSSL
   /// should not be available at the default locations.
   DynamicLibrary? get libCryptoInstance => null;
+
+  /// Adjusts the security level that is used by OpenSSL for DTLS.
+  ///
+  /// The possible security levels range from 0 to 5.
+  /// See the [OpenSSL Documentation] for more information on the meaning of
+  /// each level.
+  ///
+  /// [OpenSSL Documentation]: https://docs.openssl.org/master/man3/SSL_CTX_set_security_level/#default-callback-behaviour
+  int? get openSslSecurityLevel => null;
 }

--- a/lib/src/network/coap_inetwork.dart
+++ b/lib/src/network/coap_inetwork.dart
@@ -92,6 +92,7 @@ abstract class CoapINetwork {
           libCrypto: config.libCryptoInstance,
           libSsl: config.libSslInstance,
           hostName: uri.host,
+          securityLevel: config.openSslSecurityLevel,
         );
       default:
         throw UnsupportedProtocolException(uri.scheme);

--- a/lib/src/network/coap_network_openssl.dart
+++ b/lib/src/network/coap_network_openssl.dart
@@ -65,6 +65,7 @@ class CoapNetworkUDPOpenSSL extends CoapNetworkUDP {
     final DynamicLibrary? libSsl,
     final DynamicLibrary? libCrypto,
     final String? hostName,
+    final int? securityLevel,
   })  : _ciphers = ciphers,
         _verify = verify,
         _withTrustedRoots = withTrustedRoots,
@@ -72,6 +73,7 @@ class CoapNetworkUDPOpenSSL extends CoapNetworkUDP {
         _libSsl = libSsl,
         _libCrypto = libCrypto,
         _hostname = hostName,
+        _securityLevel = securityLevel,
         _openSslPskCallback = _createOpenSslPskCallback(pskCredentialsCallback);
 
   DtlsClient? _dtlsClient;
@@ -93,6 +95,8 @@ class CoapNetworkUDPOpenSSL extends CoapNetworkUDP {
   final DynamicLibrary? _libCrypto;
 
   final String? _hostname;
+
+  final int? _securityLevel;
 
   @override
   void send(final CoapMessage coapMessage) {
@@ -132,6 +136,7 @@ class CoapNetworkUDPOpenSSL extends CoapNetworkUDP {
       rootCertificates: _rootCertificates,
       ciphers: _ciphers,
       pskCredentialsCallback: _openSslPskCallback,
+      securityLevel: _securityLevel,
     );
 
     try {


### PR DESCRIPTION
As discussed in https://github.com/shamblett/coap/pull/200, this PR adds the ability to override the security level used by OpenSSL.  This allows for still using cipher suites like `TLS_PSK_WITH_AES_128_CCM_8` that must be supported by CoAP implementations (see [section 9.1.3.1](https://datatracker.ietf.org/doc/html/rfc7252#section-9.1.3.1) of RFC 7252), as more recent versions of OpenSSL are not allowing them to be used anymore without lowering the security level.

The DTLS example is adjusted accordingly so that it now works again.